### PR TITLE
Support multiple proxies for `mcp_server()` instances

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     ellmer,
     jsonlite,
     later,
-    nanonext (>= 1.5.2.9010),
+    nanonext (>= 1.5.2.9012),
     promises,
     rlang
 Depends: R (>= 4.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,14 +19,14 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.9000
 Imports: 
     btw (>= 0.0.1.9000),
     cli,
     ellmer,
     jsonlite,
     later,
-    nanonext (>= 1.5.2.9009),
+    nanonext (>= 1.5.2.9010),
     promises,
     rlang
 Depends: R (>= 4.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-5676-5107")),
     person("Winston", "Chang", , "winston@posit.co", role = "aut",
            comment = c(ORCID = "0000-0001-5676-5107")),
+    person("Charlie", "Gao", , "charlie.gao@posit.co", role = "aut",
+           comment = c(ORCID = "0000-0002-0750-061X")),
     person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: The goal of acquaint is to enable LLM-enabled tools like Claude Code to 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,11 +4,11 @@ Version: 0.0.0.9000
 Authors@R: c(
     person("Simon", "Couch", , "simon.couch@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5676-5107")),
-    person("Winston", "Chang", , "winston@posit.co", role = "aut",
-           comment = c(ORCID = "0000-0001-5676-5107")),
+    person("Winston", "Chang", , "winston@posit.co", role = "aut"),
     person("Charlie", "Gao", , "charlie.gao@posit.co", role = "aut",
            comment = c(ORCID = "0000-0002-0750-061X")),
-    person("Posit Software, PBC", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"),
+           comment = c(ROR = "03wc8by49"))
   )
 Description: The goal of acquaint is to enable LLM-enabled tools like Claude Code to 
     learn about the R packages you have installed using the 

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -1,20 +1,14 @@
 # This R script is a proxy. It takes input on stdin, and when the input forms
 # valid JSON, it will send the JSON to the server. Then, when it receives the
 # response, it will print the response to stdout.
-#' @param i integer instance number.
 #' @rdname mcp
 #' @export
-mcp_proxy <- function(i = 1L) {
+mcp_proxy <- function() {
   # TODO: should this actually be a check for being called within Rscript or not?
   check_not_interactive()
-  i <- as.integer(i)
-  if (is.na(i))
-    abort("`i` should be an integer value")
 
   the$proxy_socket <- nanonext::socket("poly")
-  suppressWarnings(
-    nanonext::dial(the$proxy_socket, url = sprintf("%s%d", acquaint_socket, i))
-  )
+  nanonext::dial(the$proxy_socket, url = sprintf("%s%d", acquaint_socket, 1L))
 
   # Note that we're using file("stdin") instead of stdin(), which are not the
   # same.
@@ -110,6 +104,10 @@ schedule_handle_message_from_client <- function() {
 }
 
 handle_message_from_server <- function(data) {
+  if (!is.character(data)) {
+    return()
+  }
+
   schedule_handle_message_from_server()
 
   logcat("FROM SERVER: ", data)
@@ -207,4 +205,30 @@ check_not_interactive <- function(call = caller_env()) {
       call = call
     )
   }
+}
+
+mcp_discover <- function() {
+  sock <- nanonext::socket("poly")
+  on.exit(nanonext:::reap(sock))
+  cv <- nanonext::cv()
+  monitor <- nanonext::monitor(sock, cv)
+  suppressWarnings(
+    for (i in seq_len(1024L)) {
+      nanonext::dial(sock, url = sprintf("%s%d", acquaint_socket, i), autostart = NA) &&
+        break
+    }
+  )
+  pipes <- nanonext::read_monitor(monitor)
+  res <- lapply(seq_along(pipes), function(x) nanonext::recv_aio(sock))
+  lapply(pipes, function(x) nanonext::send_aio(sock, "", mode = "raw", pipe = x))
+  nanonext::collect_aio_(res)
+}
+
+select_server <- function(i) {
+  lapply(the$proxy_socket[["dialer"]], nanonext::reap)
+  attr(the$proxy_socket, "dialer") <- NULL
+  nanonext::dial(
+    the$proxy_socket,
+    url = sprintf("%s%d", acquaint_socket, as.integer(i))
+  )
 }

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -126,7 +126,7 @@ schedule_handle_message_from_server <- function() {
 forward_request <- function(data) {
   logcat("TO SERVER: ", data)
 
-  the$saio <- nanonext::send_aio(the$proxy_socket, data, mode = "raw")
+  nanonext::send_aio(the$proxy_socket, data, mode = "raw")
 }
 
 # This process will be launched by the MCP client, so stdout/stderr aren't

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -7,7 +7,11 @@ mcp_proxy <- function() {
   # TODO: should this actually be a check for being called within Rscript or not?
   check_not_interactive()
 
-  the$proxy_socket <- nanonext::socket("pair", dial = acquaint_socket)
+  the$proxy_socket <- nanonext::socket("poly")
+  i <- 1L
+  suppressWarnings(
+    nanonext::dial(the$proxy_socket, url = sprintf("%s%d", acquaint_socket, i))
+  )
 
   # Note that we're using file("stdin") instead of stdin(), which are not the
   # same.

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -1,14 +1,17 @@
 # This R script is a proxy. It takes input on stdin, and when the input forms
 # valid JSON, it will send the JSON to the server. Then, when it receives the
 # response, it will print the response to stdout.
+#' @param i integer instance number.
 #' @rdname mcp
 #' @export
-mcp_proxy <- function() {
+mcp_proxy <- function(i = 1L) {
   # TODO: should this actually be a check for being called within Rscript or not?
   check_not_interactive()
+  i <- as.integer(i)
+  if (is.na(i))
+    abort("`i` should be an integer value")
 
   the$proxy_socket <- nanonext::socket("poly")
-  i <- 1L
   suppressWarnings(
     nanonext::dial(the$proxy_socket, url = sprintf("%s%d", acquaint_socket, i))
   )

--- a/R/server.R
+++ b/R/server.R
@@ -53,7 +53,15 @@ mcp_serve <- function() {
     return(invisible())
   }
 
-  the$server_socket <- nanonext::socket("pair", listen = acquaint_socket)
+  the$server_socket <- nanonext::socket("poly")
+  i <- 1L
+  suppressWarnings(
+    repeat {
+      nanonext::listen(the$server_socket, url = sprintf("%s%d", acquaint_socket, i)) || break
+      i <- i + 1L
+    }
+  )
+
   schedule_handle_message_from_proxy()
 }
 

--- a/R/server.R
+++ b/R/server.R
@@ -56,7 +56,7 @@ mcp_serve <- function() {
   the$server_socket <- nanonext::socket("poly")
   i <- 1L
   suppressWarnings(
-    repeat {
+    while (i < 65536L) { # prevent indefinite loop
       nanonext::listen(the$server_socket, url = sprintf("%s%d", acquaint_socket, i)) || break
       i <- i + 1L
     }

--- a/R/server.R
+++ b/R/server.R
@@ -108,13 +108,7 @@ handle_message_from_proxy <- function(msg) {
   }
   # cat("SEND:", to_json(body), "\n", sep = "", file = stderr())
 
-  # TODO: consider if better / more robust using synchronous sends
-  the$saio <- nanonext::send_aio(
-    the$server_socket,
-    to_json(body),
-    mode = "raw",
-    pipe = pipe
-  )
+  nanonext::send_aio(the$server_socket, to_json(body), mode = "raw", pipe = pipe)
 }
 
 schedule_handle_message_from_proxy <- function() {

--- a/R/server.R
+++ b/R/server.R
@@ -56,7 +56,7 @@ mcp_serve <- function() {
   the$server_socket <- nanonext::socket("poly")
   i <- 1L
   suppressWarnings(
-    while (i < 65536L) { # prevent indefinite loop
+    while (i < 1024L) { # prevent indefinite loop
       nanonext::listen(the$server_socket, url = sprintf("%s%d", acquaint_socket, i)) || break
       i <- i + 1L
     }
@@ -70,6 +70,9 @@ handle_message_from_proxy <- function(msg) {
   schedule_handle_message_from_proxy()
 
   # cat("RECV :", msg, "\n", sep = "", file = stderr())
+  if (!nzchar(msg)) {
+    return(nanonext::send_aio(the$server_socket, commandArgs(), pipe = pipe))
+  }
   data <- jsonlite::parse_json(msg)
 
   if (data$method == "tools/call") {

--- a/R/server.R
+++ b/R/server.R
@@ -66,6 +66,7 @@ mcp_serve <- function() {
 }
 
 handle_message_from_proxy <- function(msg) {
+  pipe <- the$raio[["aio"]]
   schedule_handle_message_from_proxy()
 
   # cat("RECV :", msg, "\n", sep = "", file = stderr())
@@ -108,12 +109,17 @@ handle_message_from_proxy <- function(msg) {
   # cat("SEND:", to_json(body), "\n", sep = "", file = stderr())
 
   # TODO: consider if better / more robust using synchronous sends
-  the$saio <- nanonext::send_aio(the$server_socket, to_json(body), mode = "raw")
+  the$saio <- nanonext::send_aio(
+    the$server_socket,
+    to_json(body),
+    mode = "raw",
+    pipe = pipe
+  )
 }
 
 schedule_handle_message_from_proxy <- function() {
-  r <- nanonext::recv_aio(the$server_socket, mode = "string")
-  promises::as.promise(r)$then(handle_message_from_proxy)$catch(function(e) {
+  the$raio <- nanonext::recv_aio(the$server_socket, mode = "string")
+  promises::as.promise(the$raio)$then(handle_message_from_proxy)$catch(function(e) {
     print(e)
   })
 }

--- a/R/server.R
+++ b/R/server.R
@@ -66,7 +66,7 @@ mcp_serve <- function() {
 }
 
 handle_message_from_proxy <- function(msg) {
-  pipe <- the$raio[["aio"]]
+  pipe <- nanonext::pipe_id(the$raio)
   schedule_handle_message_from_proxy()
 
   # cat("RECV :", msg, "\n", sep = "", file = stderr())

--- a/man/acquaint-package.Rd
+++ b/man/acquaint-package.Rd
@@ -25,6 +25,7 @@ Useful links:
 Authors:
 \itemize{
   \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0001-5676-5107}{ORCID})
+  \item Charlie Gao \email{charlie.gao@posit.co} (\href{https://orcid.org/0000-0002-0750-061X}{ORCID})
 }
 
 Other contributors:

--- a/man/acquaint-package.Rd
+++ b/man/acquaint-package.Rd
@@ -24,13 +24,13 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0001-5676-5107}{ORCID})
+  \item Winston Chang \email{winston@posit.co}
   \item Charlie Gao \email{charlie.gao@posit.co} (\href{https://orcid.org/0000-0002-0750-061X}{ORCID})
 }
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }

--- a/man/mcp.Rd
+++ b/man/mcp.Rd
@@ -6,12 +6,9 @@
 \alias{mcp_serve}
 \title{Model context protocol for your R session}
 \usage{
-mcp_proxy(i = 1L)
+mcp_proxy()
 
 mcp_serve()
-}
-\arguments{
-\item{i}{integer instance number.}
 }
 \description{
 Together, these functions implement a model context protocol server for your

--- a/man/mcp.Rd
+++ b/man/mcp.Rd
@@ -6,9 +6,12 @@
 \alias{mcp_serve}
 \title{Model context protocol for your R session}
 \usage{
-mcp_proxy()
+mcp_proxy(i = 1L)
 
 mcp_serve()
+}
+\arguments{
+\item{i}{integer instance number.}
 }
 \description{
 Together, these functions implement a model context protocol server for your


### PR DESCRIPTION
This is the first PR to support multiple client / server combinations.

- `mcp_server()` may be called in different R sessions and their URLs will automatically increment.
- Each `mcp_server()` instance supports multiple proxies connected to it, i.e. different apps at the same time.

The client - proxy - server relationship is still 1-1-1 as the client e.g. Claude Desktop assumes it is talking to a single server. So, for now, we also have:
- `mcp_proxy()` gains an `i` instance argument to connect to a specific server.
