### PR TITLE
Implements bridging stdin to a nanonext socket

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     ellmer,
     jsonlite,
     later,
-    nanonext (>= 1.5.2.9012),
+    nanonext (>= 1.5.2.9015),
     promises,
     rlang
 Depends: R (>= 4.1.0)


### PR DESCRIPTION
Avoids `later::later_fd()` on a `0` file descriptor altogether.

Hence adds support for Windows!

As we're just dealing with nanonext messages now, this future-proofs the design for more sophisticated usage patterns.

Uses the newly-implemented `nanonext::read_stdin()`.

FYI @wch.