### PR TITLE
allow the model to list and select hosts

### DIFF
--- a/R/host.R
+++ b/R/host.R
@@ -82,7 +82,10 @@ handle_message_from_server <- function(msg) {
 
   if (data$method == "tools/call") {
     name <- data$params$name
-    fn <- getNamespace("btw")[[name]]
+
+    # TODO: retrieve the function definitions directly from the configured tools
+    # (#12)
+    fn <- getNamespace("btw")[[name]] %||% getNamespace("acquaint")[[name]]
     args <- data$params$arguments
 
     # HACK for btw_tool_env_describe_environment. In the JSON, it will have

--- a/R/host.R
+++ b/R/host.R
@@ -153,7 +153,7 @@ drop_nulls <- function(x) {
 # Enough information for the user to be able to identify which
 # session is which when using `list_r_sessions()` (#18)
 describe_session <- function() {
-  paste0(the$i, ": ", basename(getwd()), " (", infer_ide(), ")")
+ sprintf("%d: %s (%s)", the$i, basename(getwd()), infer_ide())
 }
 
 infer_ide <- function() {

--- a/R/host.R
+++ b/R/host.R
@@ -99,18 +99,7 @@ handle_message_from_server <- function(msg) {
     tool_call_result <- do.call(fn, args)
     # cat(paste(capture.output(str(body)), collapse="\n"), file=stderr())
 
-    body <- jsonrpc_response(
-      data$id,
-      list(
-        content = list(
-          list(
-            type = "text",
-            text = paste(tool_call_result, collapse = "\n")
-          )
-        ),
-        isError = FALSE
-      )
-    )
+    body <- as_tool_call_result(data, tool_call_result)
   } else {
     body <- jsonrpc_response(
       data$id,
@@ -124,6 +113,21 @@ handle_message_from_server <- function(msg) {
     to_json(body),
     mode = "raw",
     pipe = pipe
+  )
+}
+
+as_tool_call_result <- function(data, result) {
+  jsonrpc_response(
+    data$id,
+    list(
+      content = list(
+        list(
+          type = "text",
+          text = paste(result, collapse = "\n")
+        )
+      ),
+      isError = FALSE
+    )
   )
 }
 

--- a/R/host.R
+++ b/R/host.R
@@ -66,6 +66,7 @@ mcp_host <- function() {
       i <- i + 1L
     }
   )
+  the$i <- i
 
   schedule_handle_message_from_server()
 }
@@ -152,7 +153,7 @@ drop_nulls <- function(x) {
 # Enough information for the user to be able to identify which
 # session is which when using `list_r_sessions()` (#18)
 describe_session <- function() {
-  paste0(basename(getwd()), " (", infer_ide(), ")")
+  paste0(the$i, ": ", basename(getwd()), " (", infer_ide(), ")")
 }
 
 infer_ide <- function() {

--- a/R/host.R
+++ b/R/host.R
@@ -76,7 +76,7 @@ handle_message_from_server <- function(msg) {
 
   # cat("RECV :", msg, "\n", sep = "", file = stderr())
   if (!nzchar(msg)) {
-    return(nanonext::send_aio(the$host_socket, commandArgs(), pipe = pipe))
+    return(nanonext::send_aio(the$host_socket, describe_session(), pipe = pipe))
   }
   data <- jsonlite::parse_json(msg)
 
@@ -147,4 +147,20 @@ schedule_handle_message_from_server <- function() {
 # Given a vector or list, drop all the NULL items in it
 drop_nulls <- function(x) {
   x[!vapply(x, is.null, FUN.VALUE = logical(1))]
+}
+
+# Enough information for the user to be able to identify which
+# session is which when using `list_r_sessions()` (#18)
+describe_session <- function() {
+  paste0(basename(getwd()), " (", infer_ide(), ")")
+}
+
+infer_ide <- function() {
+  first_cmd_arg <- commandArgs()[1]
+  switch(
+    first_cmd_arg,
+    ark = "Positron",
+    RStudio = "RStudio",
+    first_cmd_arg
+  )
 }

--- a/R/server.R
+++ b/R/server.R
@@ -79,10 +79,19 @@ handle_message_from_client <- function(fdstatus) {
 
     cat_json(res)
   } else if (data$method == "tools/call") {
-    result <- forward_request(buf)
-
-    # } else if (data$method == "prompts/list") {
-    # } else if (data$method == "resources/list") {
+    tool_name <- data$params$name
+    if (tool_name %in% c("list_r_sessions", "select_r_session")) {
+      # two tools provided by acquaint itself which must be executed in
+      # the server session rather than a host (#18)
+      result <- as_tool_call_result(
+        data,
+        do.call(tool_name, data$params$arguments)
+      )
+      logcat(c("FROM SERVER: ", to_json(result)))
+      cat_json(result)
+    } else {
+      result <- forward_request(buf)
+    }
   } else if (is.null(data$id)) {
     # If there is no `id` in the request, then this is a notification and the
     # client does not expect a response.

--- a/R/tools.R
+++ b/R/tools.R
@@ -33,7 +33,10 @@ list_r_sessions_tool <-
       "List the R sessions that are available to access.",
       "R sessions which have run `acquaint::mcp_host()` will appear here.",
       "In general, do not use this tool unless asked to list or",
-      "select a specific R session."
+      "select a specific R session.",
+      "Given the output of this tool, report the users to the user.",
+      "Do NOT make a choice of R session based on the results of the tool",
+      "and call select_r_session unless the user asks you to specifically."
     )
   )
 
@@ -56,6 +59,9 @@ select_r_session_tool <-
       "In general, do not use this tool unless asked to select a specific R",
       "session; the tools available to you have a default R session",
       "that is usually the one the user wants.",
+      "Do not call this tool immediately after calling list_r_sessions",
+      "unless you've been asked to select an R session and haven't yet",
+      "called list_r_sessions.",
       "Your choice of session will persist after the tool is called; only",
       "call this tool more than once if you need to switch between sessions."
     ),

--- a/R/tools.R
+++ b/R/tools.R
@@ -44,7 +44,7 @@ select_r_session <- function(i) {
     the$server_socket,
     url = sprintf("%s%d", acquaint_socket, as.integer(i))
   )
-  paste0("Selected session ", i, "successfully.")
+  paste0("Selected session ", i, " successfully.")
 }
 
 select_r_session_tool <-

--- a/R/tools.R
+++ b/R/tools.R
@@ -22,8 +22,7 @@ list_r_sessions <- function() {
     pipes,
     function(x) nanonext::send_aio(sock, "", mode = "raw", pipe = x)
   )
-  # Convert the list result from nanonext to string
-  btw::btw_this(nanonext::collect_aio_(res))
+  sort(as.character(nanonext::collect_aio_(res)))
 }
 
 list_r_sessions_tool <-

--- a/R/tools.R
+++ b/R/tools.R
@@ -1,0 +1,65 @@
+# These two functions are supplied to the client as tools and allow the client
+# to discover R sessions which have called `acquaint::mcp_host()`. They
+# are "model-facing" rather than user-facing.
+list_r_sessions <- function() {
+  sock <- nanonext::socket("poly")
+  on.exit(nanonext::reap(sock))
+  cv <- nanonext::cv()
+  monitor <- nanonext::monitor(sock, cv)
+  suppressWarnings(
+    for (i in seq_len(1024L)) {
+      nanonext::dial(
+        sock,
+        url = sprintf("%s%d", acquaint_socket, i),
+        autostart = NA
+      ) &&
+        break
+    }
+  )
+  pipes <- nanonext::read_monitor(monitor)
+  res <- lapply(seq_along(pipes), function(x) nanonext::recv_aio(sock))
+  lapply(
+    pipes,
+    function(x) nanonext::send_aio(sock, "", mode = "raw", pipe = x)
+  )
+  # Convert the list result from nanonext to string
+  btw::btw_this(nanonext::collect_aio_(res))
+}
+
+list_r_sessions_tool <-
+  ellmer::tool(
+    .fun = list_r_sessions,
+    .description = paste(
+      "List the R sessions that are available to access.",
+      "R sessions which have run `acquaint::mcp_host()` will appear here.",
+      "In general, do not use this tool unless asked to list or",
+      "select a specific R session."
+    )
+  )
+
+select_r_session <- function(i) {
+  lapply(the$server_socket[["dialer"]], nanonext::reap)
+  attr(the$server_socket, "dialer") <- NULL
+  nanonext::dial(
+    the$server_socket,
+    url = sprintf("%s%d", acquaint_socket, as.integer(i))
+  )
+  paste0("Selected session ", i, "successfully.")
+}
+
+select_r_session_tool <-
+  ellmer::tool(
+    .fun = select_r_session,
+    .description = paste(
+      "Choose the R session host of interest.",
+      "Use the `list_r_sessions` tool to discover potential sessions.",
+      "In general, do not use this tool unless asked to select a specific R",
+      "session; the tools available to you have a default R session",
+      "that is usually the one the user wants.",
+      "Your choice of session will persist after the tool is called; only",
+      "call this tool more than once if you need to switch between sessions."
+    ),
+    i = ellmer::type_integer("The index of the host session to select.")
+  )
+
+.acquaint_tools <- list(list_r_sessions_tool, select_r_session_tool)


### PR DESCRIPTION
An initial go at #14, but not yet working.

`mcp_discover()` becomes `list_r_sessions()` and `select_host()` becomes `select_r_session()`.

Currently, `list_r_sessions()` is executed in the default host process rather than a fresh one, so there's a long hang when the tool is called. @shikokuchuo: I can spin up a fresh process to run this tool if needed, but is it a straightforward change to allow that function to be run in one of the host sessions? This is where other tools are executed, so that's the happy path.