### PR TITLE
Ensure MCP Server Exits Cleanly with the Client

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     cli,
     ellmer,
     jsonlite,
-    later,
     nanonext (>= 1.5.2.9015),
     promises,
     rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     cli,
     ellmer,
     jsonlite,
-    nanonext (>= 1.5.2.9015),
+    nanonext (>= 1.5.2.9016),
     promises,
     rlang
 Depends: R (>= 4.1.0)

--- a/R/server.R
+++ b/R/server.R
@@ -19,9 +19,7 @@ mcp_server <- function() {
   client <- nanonext::recv_aio(reader_socket, mode = "string", cv = cv)
   host <- nanonext::recv_aio(the$server_socket, mode = "string", cv = cv)
 
-  repeat {
-
-    nanonext::wait(cv) || break
+  while (nanonext::wait(cv)) {
 
     if (!nanonext::unresolved(host)) {
       handle_message_from_host(host$data)

--- a/R/server.R
+++ b/R/server.R
@@ -9,11 +9,11 @@ mcp_server <- function() {
 
   cv <- nanonext::cv()
   reader_socket <- nanonext::read_stdin()
-  on.exit(close(reader_socket))
+  on.exit(nanonext::reap(reader_socket))
   nanonext::pipe_notify(reader_socket, cv, remove = TRUE, flag = TRUE)
 
   the$server_socket <- nanonext::socket("poly")
-  on.exit(close(the$server_socket), add = TRUE)
+  on.exit(nanonext::reap(the$server_socket), add = TRUE)
   nanonext::dial(the$server_socket, url = sprintf("%s%d", acquaint_socket, 1L))
 
   client <- nanonext::recv_aio(reader_socket, mode = "string", cv = cv)


### PR DESCRIPTION
Closes #19.

When the client closes `stdout` (required by the MCP protocol standard), our `stdin` at the server returns `EOF`, which causes the internal socket (on a background thread) to close. This in turn drops the connection to our `reader_socket` and as with any type of pipe event, we can use `nanonext::pipe_notify()` to have this signal a condition variable.

To implement this, I've made our MCP server event loop explicit:
1. This has the added advantage of eliminating the use of promises and the later loop within the MCP server, allowing for potentially much higher throughput.
2. Stylistically it might not be as nice as having the callbacks, but this frees us up to add more complex behaviours if needed down the line (without needing to temporarily cancel the aios/promises to exit out of those loops).
3. Having a single synchronization point at the `wait()` call makes it easier to reason about the code, and to sequence the order of calls coming out of that, rather than having it all happen 'asynchronously' in the background.

Again, tagging @wch - let me know if you have any comments.