### PR TITLE
Facilitate session selection

### DIFF
--- a/R/host.R
+++ b/R/host.R
@@ -77,7 +77,14 @@ handle_message_from_server <- function(msg) {
 
   # cat("RECV :", msg, "\n", sep = "", file = stderr())
   if (!nzchar(msg)) {
-    return(nanonext::send_aio(the$host_socket, describe_session(), pipe = pipe))
+    return(
+      nanonext::send_aio(
+        the$host_socket,
+        describe_session(),
+        mode = "raw",
+        pipe = pipe
+      )
+    )
   }
   data <- jsonlite::parse_json(msg)
 

--- a/R/host.R
+++ b/R/host.R
@@ -66,7 +66,7 @@ mcp_host <- function() {
       i <- i + 1L
     }
   )
-  the$i <- i
+  the$session <- i
 
   schedule_handle_message_from_server()
 }
@@ -160,7 +160,7 @@ drop_nulls <- function(x) {
 # Enough information for the user to be able to identify which
 # session is which when using `list_r_sessions()` (#18)
 describe_session <- function() {
- sprintf("%d: %s (%s)", the$i, basename(getwd()), infer_ide())
+ sprintf("%d: %s (%s)", the$session, basename(getwd()), infer_ide())
 }
 
 infer_ide <- function() {

--- a/R/tools.R
+++ b/R/tools.R
@@ -8,16 +8,21 @@ list_r_sessions <- function() {
   monitor <- nanonext::monitor(sock, cv)
   suppressWarnings(
     for (i in seq_len(1024L)) {
-      nanonext::dial(
-        sock,
-        url = sprintf("%s%d", acquaint_socket, i),
-        autostart = NA
-      ) &&
+      if (
+        nanonext::dial(
+          sock,
+          url = sprintf("%s%d", acquaint_socket, i),
+          autostart = NA
+        ) && i > 8L
+      )
         break
     }
   )
   pipes <- nanonext::read_monitor(monitor)
-  res <- lapply(seq_along(pipes), function(x) nanonext::recv_aio(sock))
+  res <- lapply(
+    pipes,
+    function(x) nanonext::recv_aio(sock, mode = "string")
+  )
   lapply(
     pipes,
     function(x) nanonext::send_aio(sock, "", mode = "raw", pipe = x)
@@ -31,6 +36,7 @@ list_r_sessions_tool <-
     .description = paste(
       "List the R sessions that are available to access.",
       "R sessions which have run `acquaint::mcp_host()` will appear here.",
+      "Include the session number 'i' in the output.",
       "In general, do not use this tool unless asked to list or",
       "select a specific R session.",
       "Given the output of this tool, report the users to the user.",

--- a/R/tools.R
+++ b/R/tools.R
@@ -46,7 +46,7 @@ list_r_sessions_tool <-
   )
 
 select_r_session <- function(i) {
-  lapply(the$server_socket[["dialer"]], nanonext::reap)
+  nanonext::reap(the$server_socket[["dialer"]][[1L]])
   attr(the$server_socket, "dialer") <- NULL
   nanonext::dial(
     the$server_socket,

--- a/R/tools.R
+++ b/R/tools.R
@@ -36,7 +36,8 @@ list_r_sessions_tool <-
     .description = paste(
       "List the R sessions that are available to access.",
       "R sessions which have run `acquaint::mcp_host()` will appear here.",
-      "Include the session number 'i' in the output.",
+      "In the output, start each session with 'Session #' and do NOT otherwise",
+      "prefix any index numbers to the output.",
       "In general, do not use this tool unless asked to list or",
       "select a specific R session.",
       "Given the output of this tool, report the users to the user.",


### PR DESCRIPTION
Closes #14.

This PR implements:

1. Now the response to a `list_r_sessions` tool call shows the session number `i` instead of the sessions just being a numbered list. This makes it much easier to select a session by number.
2. I've made discovery default to at least 8 sessions (we always attempt to dial 1 - 8) so that they can really come and go. I think this is probably enough, but it's not very costly to dial a few additional IPC socket addresses if we wanted to.
3. As `describe_session()` only generates text, we can also use raw mode sends for that query (avoiding R serialization).

@simonpcouch feel free to optimize the prompt if you see a way to do this! Another FYI @wch.

