### PR TITLE
Implement error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     cli,
     ellmer (>= 0.2.0),
     jsonlite,
-    nanonext (>= 1.5.2.9019),
+    nanonext (>= 1.6.0),
     promises,
     rlang
 Depends: R (>= 4.1.0)
@@ -37,6 +37,5 @@ URL: https://github.com/simonpcouch/acquaint, https://simonpcouch.github.io/acqu
 BugReports: https://github.com/simonpcouch/acquaint/issues
 Config/Needs/website: tidyverse/tidytemplate
 Remotes:
-    posit-dev/btw,
-    r-lib/nanonext
+    posit-dev/btw
 VignetteBuilder: knitr

--- a/R/session.R
+++ b/R/session.R
@@ -109,7 +109,7 @@ handle_message_from_server <- function(msg) {
 
     error_message <- NULL
     tool_call_result <- tryCatch(do.call(fn, args), error = \(e) {
-      error_message <- conditionMessage(e)
+      error_message <<- conditionMessage(e)
       substitute()
     })
 

--- a/R/session.R
+++ b/R/session.R
@@ -107,10 +107,21 @@ handle_message_from_server <- function(msg) {
       }
     }
 
-    tool_call_result <- do.call(fn, args)
+    error_message <- NULL
+    tool_call_result <- tryCatch(do.call(fn, args), error = \(e) {
+      error_message <- conditionMessage(e)
+      substitute()
+    })
+
+    body <- if (missing(tool_call_result))
+      jsonrpc_response(
+        data$id,
+        error = list(code = -32603, message = error_message)
+      ) else
+        as_tool_call_result(data, tool_call_result)
+
     # cat(paste(capture.output(str(body)), collapse="\n"), file=stderr())
 
-    body <- as_tool_call_result(data, tool_call_result)
   } else {
     body <- jsonrpc_response(
       data$id,
@@ -145,10 +156,8 @@ as_tool_call_result <- function(data, result) {
 schedule_handle_message_from_server <- function() {
   the$raio <- nanonext::recv_aio(the$session_socket, mode = "string")
   promises::as.promise(the$raio)$then(handle_message_from_server)$catch(
-    function(
-      e
-    ) {
-      print(e)
+    \(e) {
+      # no op but ensures promise is never rejected
     }
   )
 }

--- a/R/session.R
+++ b/R/session.R
@@ -107,18 +107,15 @@ handle_message_from_server <- function(msg) {
       }
     }
 
-    error_message <- NULL
-    tool_call_result <- tryCatch(do.call(fn, args), error = \(e) {
-      error_message <<- conditionMessage(e)
-      substitute()
-    })
-
-    body <- if (missing(tool_call_result))
-      jsonrpc_response(
-        data$id,
-        error = list(code = -32603, message = error_message)
-      ) else
-        as_tool_call_result(data, tool_call_result)
+    body <- tryCatch(
+      as_tool_call_result(data, do.call(fn, args)),
+      error = \(e) {
+        jsonrpc_response(
+          data$id,
+          error = list(code = -32603, message = conditionMessage(e))
+        )
+      }
+    )
 
     # cat(paste(capture.output(str(body)), collapse="\n"), file=stderr())
 


### PR DESCRIPTION
Closes #27.

- The promises catch method should do nothing except ensure the promise is never rejected, as we don't want any console output in a user session.
- The most likely site for errors is in this [`do.call()` invocation](https://github.com/simonpcouch/acquaint/blob/main/R/session.R#L110). Now an error here will cause an 'internal error -32603' to be returned (along with the error message). Clients such as Claude Desktop will then be able to read the error and advise appropriately.

It might be we need to cover more error cases, but we should be able to handle them in a similar way.

To trigger, for a Positron session (on Mac), ask "what files are in the parent directory". The response will then be:
> Error executing code: MCP error -32603: [1m [22mYou are not allowed to list or read files outside of the project directory. Make
sure that `path` is relative to the current working directory.