### PR TITLE
feat(server): Add protocol version negotiation and clarify server flow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcptools
 Title: Model Context Protocol Servers and Clients
-Version: 0.2.0.9000
+Version: 0.3.0
 Authors@R: c(
     person("Simon", "Couch", , "simon.couch@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5676-5107")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # mcptools (development version)
 
+# mcptools 0.3.0
+
+## Server
+
+* The server now negotiates a protocol version with clients during initialization per the MCP specification. Supported versions include `2024-11-05`, `2025-03-26`, `2025-06-18`, and `2025-11-25`.
+
+* `mcp_server()` gains a new `instructions` argument, allowing users to provide custom server instructions that are included in the capabilities response sent to clients.
+ 
+* HTTP transport now generates and returns a unique session ID via the `Mcp-Session-Id` response header during initialization.
+
+* The `serverInfo.version` in the capabilities response now reflects the actual installed package version rather than a hardcoded value.
+
+* Tools without arguments now include an explicit empty `properties` object in their JSON schema, preventing missing fields.
+
+* Fixed an issue where the stdio message handler did not return early after sending an error response for invalid requests.
+
+* Fixed HTTP session validation to correctly reject unknown or expired session IDs.
+
 # mcptools 0.2.0
 
 ## Server

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,2 +1,3 @@
 the <- new_environment()
 the$server_processes <- list()
+the$http_protocol_versions <- list()

--- a/R/client.R
+++ b/R/client.R
@@ -244,10 +244,15 @@ add_mcp_server <- function(config, name, call = caller_env()) {
     },
     error = function(e) {
       if (process$get_exit_status() %in% c(1L, 2L)) {
+        # Try stderr first, fall back to stdout if empty
+        stderr_output <- process$read_all_error()
+        if (nchar(stderr_output) == 0) {
+          stderr_output <- process$read_all_output()
+        }
         cli::cli_abort(
           c(
             "The command {.code {config$command}} failed with the following error:",
-            "x" = "{paste0(process$read_all_error_lines(), collapse = '. ')}"
+            "x" = "{stderr_output}"
           ),
           call = call
         )

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -113,48 +113,22 @@ protocol_version_lt <- function(version, reference) {
   version < reference
 }
 
-#' Validate the `Mcp-Session-Id` header on an HTTP request.
-#'
-#' Per the spec (from 2025-03-26): the server MAY assign a session ID during
-#' initialization. If it does, the client MUST include `Mcp-Session-Id` on all
-#' subsequent requests. A missing header should return 400 Bad Request; an
-#' unknown/expired session ID should return 404 Not Found.
-#'
-#' @param req The Rook request environment.
-#' @return `TRUE` if the session ID is valid (maps to a known session).
-#'   Returns a list with an HTTP error response otherwise.
-#' @noRd
-validate_session_id_header <- function(req) {
-  # httpuv/Rook transforms the header to HTTP_MCP_SESSION_ID
-  session_id <- req$HTTP_MCP_SESSION_ID
-
+validate_request_headers <- function(session_id,
+                                     negotiated_protocol_version,
+                                     protocol_version_from_header) {
   if (is.null(session_id)) {
-    return(list(
-      status = 400L,
-      headers = list("Content-Type" = "application/json"),
-      body = to_json(list(
-        jsonrpc = "2.0",
-        error = list(
-          code = -32600,
-          message = "Missing required Mcp-Session-Id header"
-        )
-      ))
-    ))
+    "Missing required Mcp-Session-Id header"
+  } else if (is.null(negotiated_protocol_version)) {
+    "Unknown or expired session ID"
+  } else if (getOption("mcptools.enforce_protocol_headers", default = FALSE) &&
+               protocol_version_gte(negotiated_protocol_version, "2025-06-18")) {
+    ## For protocol versions >= 2025-06-18, both headers are required on all requests.
+    ## For backwards compatibility, we cannot enforce this for older protocol versions.
+    ## Furthermore, mcp-remote does not enforce this rule, so we allow it by default.
+    if (!identical(negotiated_protocol_version, protocol_version_from_header)) {
+      "MCP-Protocol-Version header does not match negotiated protocol version for this session"
+    }
+  } else {
+    NULL
   }
-
-  if (is.null(get_http_protocol_version(session_id))) {
-    return(list(
-      status = 404L,
-      headers = list("Content-Type" = "application/json"),
-      body = to_json(list(
-        jsonrpc = "2.0",
-        error = list(
-          code = -32600,
-          message = "Unknown or expired session ID"
-        )
-      ))
-    ))
-  }
-
-  TRUE
 }

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -70,13 +70,14 @@ get_stdio_protocol_version <- function() {
 #' @param version    Negotiated protocol version.
 #' @noRd
 set_http_protocol_version <- function(session_id, version) {
-  if (is.null(the$http_protocol_versions)) {
-    ## TODO: This will grow indefinitely as new sessions are initialized. We should
-    ## consider pruning expired sessions after some timeout, but for now this is
-    ## simpler than implementing a more complex structure for tracking session state.
-    the$http_protocol_versions <- list()
-  }
-  the$http_protocol_versions[[session_id]] <- version
+  # ensure we index the internal list with a character key so lookups using the
+  # value from HTTP headers (always character) succeed regardless of the type
+  # returned by nanonext::random().
+  session_key <- as.character(session_id)
+  ## TODO: This will grow indefinitely as new sessions are initialized. We should
+  ## consider pruning expired sessions after some timeout, but for now this is
+  ## simpler than implementing a more complex structure for tracking session state.
+  the$http_protocol_versions[[session_key]] <- version
 }
 
 #' Retrieve the negotiated version for an HTTP session.
@@ -84,57 +85,9 @@ set_http_protocol_version <- function(session_id, version) {
 #' @return The negotiated version, or `NULL` if not yet initialized.
 #' @noRd
 get_http_protocol_version <- function(session_id) {
-  the$http_protocol_versions[[session_id]]
-}
-
-#' Validate the `MCP-Protocol-Version` header on an HTTP request.
-#'
-#' Per the spec: "the client MUST include the MCP-Protocol-Version header on
-#' all subsequent requests to the MCP server."
-#'
-#' @param req The Rook request environment.
-#' @return `TRUE` if the header is valid (matches a supported version),
-#'   or if the request is an `initialize` (where the header is not expected).
-#'   Returns a list with HTTP error response otherwise.
-#' @noRd
-validate_protocol_version_header <- function(req) {
-  # The header name is transformed by httpuv/Rook: HTTP_MCP_PROTOCOL_VERSION
-  header_version <- req$HTTP_MCP_PROTOCOL_VERSION
-
-  if (is.null(header_version)) {
-    return(list(
-      status = 400L,
-      headers = list("Content-Type" = "application/json"),
-      body = to_json(list(
-        jsonrpc = "2.0",
-        error = list(
-          code = -32600,
-          message = "Missing required MCP-Protocol-Version header",
-          data = list(supported = supported_protocol_versions)
-        )
-      ))
-    ))
+  if (!is.null(session_id)) {
+    the$http_protocol_versions[[session_id]]
   }
-
-  if (!header_version %in% supported_protocol_versions) {
-    return(list(
-      status = 400L,
-      headers = list("Content-Type" = "application/json"),
-      body = to_json(list(
-        jsonrpc = "2.0",
-        error = list(
-          code = -32600,
-          message = "Unsupported protocol version in MCP-Protocol-Version header",
-          data = list(
-            supported = supported_protocol_versions,
-            requested = header_version
-          )
-        )
-      ))
-    ))
-  }
-
-  TRUE
 }
 
 #' Compare the negotiated version against a reference version.

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -1,0 +1,200 @@
+# Protocol version negotiation
+#
+# The MCP spec requires the server to negotiate a protocol version with the
+# client during initialization. The client sends its preferred version;
+# if the server supports it, the server echoes it back. Otherwise, the server
+# responds with the latest version it supports and the client may disconnect.
+#
+# Adding a new supported version:
+#   1. Append the version string to `supported_protocol_versions` below.
+#   2. If the new version introduces behavioural changes, use
+#      `protocol_version_gte()` / `protocol_version_lt()` guards in the
+#      relevant code paths rather than duplicating implementations.
+
+#' Supported MCP protocol versions, from oldest to newest.
+#' @noRd
+supported_protocol_versions <- c(
+  "2024-11-05",
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25"
+)
+
+#' The latest protocol version supported by this server.
+#' @noRd
+latest_protocol_version <- supported_protocol_versions[
+  length(supported_protocol_versions)
+]
+
+#' Negotiate a protocol version with a client.
+#'
+#' Implements the MCP version negotiation: if the client's requested version
+#' is supported, return it; otherwise return the server's latest version.
+#'
+#' @param client_version Character scalar; the `protocolVersion` from the
+#'   client's `initialize` request.
+#' @return The negotiated version string.
+#' @noRd
+negotiate_protocol_version <- function(client_version) {
+  if (client_version %in% supported_protocol_versions) {
+    client_version
+  } else {
+    latest_protocol_version
+  }
+}
+
+# -- Per-client version tracking -----------------------------------------------
+#
+# stdio: one client at a time -> store in `the$negotiated_protocol_version`.
+# HTTP:  multiple clients     -> store in `the$http_protocol_versions`,
+#        a named list keyed by mcp session id.
+
+#' Store the negotiated version for the current stdio client.
+#' @noRd
+set_stdio_protocol_version <- function(version) {
+  the$negotiated_protocol_version <- version
+}
+
+#' Retrieve the negotiated version for the current stdio client.
+#' @noRd
+get_stdio_protocol_version <- function() {
+  the$negotiated_protocol_version %||% latest_protocol_version
+}
+
+#' Store the negotiated version for an HTTP session.
+#' @param session_id Character scalar identifying the HTTP session.
+#' @param version    Negotiated protocol version.
+#' @noRd
+set_http_protocol_version <- function(session_id, version) {
+  if (is.null(the$http_protocol_versions)) {
+    the$http_protocol_versions <- list()
+  }
+  the$http_protocol_versions[[session_id]] <- version
+}
+
+#' Retrieve the negotiated version for an HTTP session.
+#' @param session_id Character scalar identifying the HTTP session.
+#' @return The negotiated version, or `NULL` if not yet initialized.
+#' @noRd
+get_http_protocol_version <- function(session_id) {
+  the$http_protocol_versions[[session_id]]
+}
+
+#' Validate the `MCP-Protocol-Version` header on an HTTP request.
+#'
+#' Per the spec: "the client MUST include the MCP-Protocol-Version header on
+#' all subsequent requests to the MCP server."
+#'
+#' @param req The Rook request environment.
+#' @return `TRUE` if the header is valid (matches a supported version),
+#'   or if the request is an `initialize` (where the header is not expected).
+#'   Returns a list with HTTP error response otherwise.
+#' @noRd
+validate_protocol_version_header <- function(req) {
+  # The header name is transformed by httpuv/Rook: HTTP_MCP_PROTOCOL_VERSION
+  header_version <- req$HTTP_MCP_PROTOCOL_VERSION
+
+  if (is.null(header_version)) {
+    return(list(
+      status = 400L,
+      headers = list("Content-Type" = "application/json"),
+      body = to_json(list(
+        jsonrpc = "2.0",
+        error = list(
+          code = -32600,
+          message = "Missing required MCP-Protocol-Version header",
+          data = list(supported = supported_protocol_versions)
+        )
+      ))
+    ))
+  }
+
+  if (!header_version %in% supported_protocol_versions) {
+    return(list(
+      status = 400L,
+      headers = list("Content-Type" = "application/json"),
+      body = to_json(list(
+        jsonrpc = "2.0",
+        error = list(
+          code = -32600,
+          message = "Unsupported protocol version in MCP-Protocol-Version header",
+          data = list(
+            supported = supported_protocol_versions,
+            requested = header_version
+          )
+        )
+      ))
+    ))
+  }
+
+  TRUE
+}
+
+#' Compare the negotiated version against a reference version.
+#'
+#' Useful for version-gating behaviour, e.g.:
+#' ```
+#' if (protocol_version_gte(version, "2025-06-18")) {
+#'   # use new behaviour
+#' }
+#' ```
+#'
+#' @param version   Character scalar; the negotiated version.
+#' @param reference Character scalar; the version to compare against.
+#' @return `TRUE` if `version >= reference` in chronological order.
+#' @noRd
+protocol_version_gte <- function(version, reference) {
+  version >= reference
+}
+
+#' @rdname protocol_version_gte
+#' @noRd
+protocol_version_lt <- function(version, reference) {
+  version < reference
+}
+
+#' Validate the `Mcp-Session-Id` header on an HTTP request.
+#'
+#' Per the spec (from 2025-03-26): the server MAY assign a session ID during
+#' initialization. If it does, the client MUST include `Mcp-Session-Id` on all
+#' subsequent requests. A missing header should return 400 Bad Request; an
+#' unknown/expired session ID should return 404 Not Found.
+#'
+#' @param req The Rook request environment.
+#' @return `TRUE` if the session ID is valid (maps to a known session).
+#'   Returns a list with an HTTP error response otherwise.
+#' @noRd
+validate_session_id_header <- function(req) {
+  # httpuv/Rook transforms the header to HTTP_MCP_SESSION_ID
+  session_id <- req$HTTP_MCP_SESSION_ID
+
+  if (is.null(session_id)) {
+    return(list(
+      status = 400L,
+      headers = list("Content-Type" = "application/json"),
+      body = to_json(list(
+        jsonrpc = "2.0",
+        error = list(
+          code = -32600,
+          message = "Missing required Mcp-Session-Id header"
+        )
+      ))
+    ))
+  }
+
+  if (is.null(get_http_protocol_version(session_id))) {
+    return(list(
+      status = 404L,
+      headers = list("Content-Type" = "application/json"),
+      body = to_json(list(
+        jsonrpc = "2.0",
+        error = list(
+          code = -32600,
+          message = "Unknown or expired session ID"
+        )
+      ))
+    ))
+  }
+
+  TRUE
+}

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -36,7 +36,11 @@ latest_protocol_version <- supported_protocol_versions[
 #' @return The negotiated version string.
 #' @noRd
 negotiate_protocol_version <- function(client_version) {
-  if (client_version %in% supported_protocol_versions) {
+  if (is.null(client_version) ||
+        !is.character(client_version) ||
+        length(client_version) != 1L) {
+    latest_protocol_version
+  } else if (client_version %in% supported_protocol_versions) {
     client_version
   } else {
     latest_protocol_version

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -67,6 +67,9 @@ get_stdio_protocol_version <- function() {
 #' @noRd
 set_http_protocol_version <- function(session_id, version) {
   if (is.null(the$http_protocol_versions)) {
+    ## TODO: This will grow indefinitely as new sessions are initialized. We should
+    ## consider pruning expired sessions after some timeout, but for now this is
+    ## simpler than implementing a more complex structure for tracking session state.
     the$http_protocol_versions <- list()
   }
   the$http_protocol_versions[[session_id]] <- version

--- a/R/server.R
+++ b/R/server.R
@@ -225,7 +225,6 @@ handle_http_request <- function(req) {
       body = to_json(list(error = "Invalid Origin"))
     ))
   }
-
   if (req$REQUEST_METHOD == "POST") {
     return(handle_http_post(req))
   } else if (req$REQUEST_METHOD == "GET") {
@@ -268,36 +267,61 @@ handle_http_post <- function(req) {
     ))
   }
 
-  if (is.null(data$id)) {
-    # Notifications are sent after initialize; validate session headers only
-    # when the negotiated version requires them (>= 2025-06-18). If the
-    # client sends a session ID, always verify it maps to a known session.
-    if (!identical(data$method, "notifications/initialized") ||
-        !is.null(req$HTTP_MCP_SESSION_ID)) {
-      session_id <- req$HTTP_MCP_SESSION_ID
-      negotiated <- if (!is.null(session_id)) {
-        get_http_protocol_version(session_id)
-      }
-      if (!is.null(negotiated) &&
-          protocol_version_gte(negotiated, "2025-06-18")) {
-        session_validation <- validate_session_id_header(req)
-        if (!isTRUE(session_validation)) {
-          return(session_validation)
-        }
-      } else if (!is.null(session_id) && is.null(negotiated)) {
-        # Session ID was sent but not recognised — always reject
-        session_validation <- validate_session_id_header(req)
-        if (!isTRUE(session_validation)) {
-          return(session_validation)
-        }
-      }
-    }
-    result <- handle_http_notification_or_response(data)
+  if (is.null(data$id) || identical(data$method, "notifications/initialized")) {
+    # Notifications are sent after initialize
     return(list(
       status = 202L,
       headers = list("Content-Type" = "application/json"),
       body = ""
     ))
+  }
+
+  session_id <- req$HTTP_MCP_SESSION_ID
+  protocol_version_header <- req$HTTP_MCP_PROTOCOL_VERSION
+  negotiated_protocol_version <- get_http_protocol_version(session_id)
+
+  if (!is.null(protocol_version_header) &&
+        protocol_version_gte(protocol_version_header, "2025-06-18")) {
+    ## For protocol versions >= 2025-06-18, both headers are required on all requests
+    if (is.null(session_id)) {
+      return(list(
+        status = 400L,
+        headers = list("Content-Type" = "application/json"),
+        body = to_json(list(
+          jsonrpc = "2.0",
+          error = list(
+            code = -32600,
+            message = "Missing required Mcp-Session-Id header"
+          )
+        ))
+      ))
+    } else {
+      if (is.null(negotiated_protocol_version)) {
+        return(list(
+          status = 404L,
+          headers = list("Content-Type" = "application/json"),
+          body = to_json(list(
+            jsonrpc = "2.0",
+            error = list(
+              code = -32600,
+              message = "Unknown or expired session ID"
+            )
+          ))
+        ))
+      } else if (!identical(negotiated_protocol_version, protocol_version_header)) {
+        return(list(
+          status = 400L,
+          headers = list("Content-Type" = "application/json"),
+          body = to_json(list(
+            jsonrpc = "2.0",
+            error = list(
+              code = -32600,
+              message = "Mcp-Protocol-Version header does not match negotiated protocol version for this session"
+            )
+          ))
+        ))
+      }
+    }
   }
 
   # Validate Mcp-Session-Id and MCP-Protocol-Version headers on non-initialize
@@ -306,48 +330,29 @@ handle_http_post <- function(req) {
   # subsequent HTTP requests. For older protocol versions we are permissive:
   # if the client sends a session ID we verify it, but we do not require either
   # header to be present.
-  if (!identical(data$method, "initialize")) {
-    session_id <- req$HTTP_MCP_SESSION_ID
-    negotiated <- if (!is.null(session_id)) {
-      get_http_protocol_version(session_id)
-    }
-
-    if (!is.null(negotiated) &&
-        protocol_version_gte(negotiated, "2025-06-18")) {
-      # Version >= 2025-06-18: enforce both headers
-      session_validation <- validate_session_id_header(req)
-      if (!isTRUE(session_validation)) {
-        return(session_validation)
-      }
-      version_validation <- validate_protocol_version_header(req)
-      if (!isTRUE(version_validation)) {
-        return(version_validation)
-      }
-    } else if (!is.null(session_id) && is.null(negotiated)) {
-      # Session ID was sent but not recognised — always reject
-      session_validation <- validate_session_id_header(req)
-      if (!isTRUE(session_validation)) {
-        return(session_validation)
-      }
-    }
-    # Otherwise (no session ID header, or version < 2025-06-18): let it through
+  if (identical(data$method, "initialize")) {
+    negotiated_protocol_version <-
+      negotiate_protocol_version(data$params$protocolVersion)
+    session_id <- nanonext::random(n = 16L)
+    set_http_protocol_version(session_id, negotiated_protocol_version)
+    return(list(
+      status = 200L,
+      headers = list(
+        "Content-Type" = "application/json",
+        "Mcp-Session-Id" = session_id
+      ),
+      body = to_json(jsonrpc_response(
+        data$id,
+        capabilities(negotiated_protocol_version, the$server_instructions)
+      ))
+    ))
   }
 
-  result <- handle_http_request_message(data, req)
-
-  headers <- list("Content-Type" = "application/json")
-
-  # Return the Mcp-Session-Id header on initialize responses so the client
-  # can include it on subsequent requests.
-  session_id <- attr(result, "mcp_session_id")
-  if (!is.null(session_id)) {
-    headers[["Mcp-Session-Id"]] <- session_id
-    attr(result, "mcp_session_id") <- NULL
-  }
+  result <- handle_http_request_message(data)
 
   list(
     status = 200L,
-    headers = headers,
+    headers = list("Content-Type" = "application/json"),
     body = to_json(result)
   )
 }
@@ -360,27 +365,8 @@ handle_http_get <- function(req) {
   )
 }
 
-handle_http_notification_or_response <- function(data) {
-  NULL
-}
-
-handle_http_request_message <- function(data, req) {
-  if (data$method == "initialize") {
-    negotiated <- negotiate_protocol_version(data$params$protocolVersion)
-    # The server always generates a session ID for internal tracking.
-    # It is only returned to the client (via response header) when the
-    # negotiated version requires it (>= 2025-06-18).
-    session_id <- nanonext::random(n = 16L)
-    set_http_protocol_version(session_id, negotiated)
-    result <- jsonrpc_response(
-      data$id,
-      capabilities(negotiated, the$server_instructions)
-    )
-    if (protocol_version_gte(negotiated, "2025-06-18")) {
-      attr(result, "mcp_session_id") <- session_id
-    }
-    return(result)
-  } else if (data$method == "tools/list") {
+handle_http_request_message <- function(data) {
+  if (data$method == "tools/list") {
     return(jsonrpc_response(
       data$id,
       list(tools = get_mcptools_tools_as_json())

--- a/R/server.R
+++ b/R/server.R
@@ -556,6 +556,9 @@ tool_as_json <- function(tool) {
   inputSchema <- compact(as_json(dummy_provider, tool@arguments))
   # This field is present but shouldn't be
   inputSchema$description <- NULL
+  if (is.null(inputSchema$properties)) {
+    inputSchema$properties <- structure(list(), names = character())
+  }
 
   list(
     name = tool@name,

--- a/R/server.R
+++ b/R/server.R
@@ -86,6 +86,8 @@
 #'   tools (`list_r_sessions`, `select_r_session`) that work with
 #'   `mcp_session()`. Defaults to `TRUE`. Note that the tools to interface with
 #'   sessions are still first routed through the `mcp_server()`.
+#' @param instructions Optional character string with custom server instructions
+#'   included in the capabilities response sent to clients.
 #'
 #' @returns
 #' `mcp_server()` and `mcp_session()` are both called primarily for their
@@ -502,7 +504,7 @@ capabilities <- function(protocol_version = latest_protocol_version,
     ),
     serverInfo = list(
       name = "R mcptools server",
-      version = as.character(packageVersion("mcptools"))
+      version = as.character(utils::packageVersion("mcptools"))
     ),
     instructions = instructions
   )

--- a/R/server.R
+++ b/R/server.R
@@ -265,6 +265,29 @@ handle_http_post <- function(req) {
   }
 
   if (is.null(data$id)) {
+    # Notifications are sent after initialize; validate session headers only
+    # when the negotiated version requires them (>= 2025-06-18). If the
+    # client sends a session ID, always verify it maps to a known session.
+    if (!identical(data$method, "notifications/initialized") ||
+        !is.null(req$HTTP_MCP_SESSION_ID)) {
+      session_id <- req$HTTP_MCP_SESSION_ID
+      negotiated <- if (!is.null(session_id)) {
+        get_http_protocol_version(session_id)
+      }
+      if (!is.null(negotiated) &&
+          protocol_version_gte(negotiated, "2025-06-18")) {
+        session_validation <- validate_session_id_header(req)
+        if (!isTRUE(session_validation)) {
+          return(session_validation)
+        }
+      } else if (!is.null(session_id) && is.null(negotiated)) {
+        # Session ID was sent but not recognised — always reject
+        session_validation <- validate_session_id_header(req)
+        if (!isTRUE(session_validation)) {
+          return(session_validation)
+        }
+      }
+    }
     result <- handle_http_notification_or_response(data)
     return(list(
       status = 202L,
@@ -273,11 +296,54 @@ handle_http_post <- function(req) {
     ))
   }
 
-  result <- handle_http_request_message(data)
+  # Validate Mcp-Session-Id and MCP-Protocol-Version headers on non-initialize
+
+  # requests. Per spec (from 2025-06-18), the client MUST include both on
+  # subsequent HTTP requests. For older protocol versions we are permissive:
+  # if the client sends a session ID we verify it, but we do not require either
+  # header to be present.
+  if (!identical(data$method, "initialize")) {
+    session_id <- req$HTTP_MCP_SESSION_ID
+    negotiated <- if (!is.null(session_id)) {
+      get_http_protocol_version(session_id)
+    }
+
+    if (!is.null(negotiated) &&
+        protocol_version_gte(negotiated, "2025-06-18")) {
+      # Version >= 2025-06-18: enforce both headers
+      session_validation <- validate_session_id_header(req)
+      if (!isTRUE(session_validation)) {
+        return(session_validation)
+      }
+      version_validation <- validate_protocol_version_header(req)
+      if (!isTRUE(version_validation)) {
+        return(version_validation)
+      }
+    } else if (!is.null(session_id) && is.null(negotiated)) {
+      # Session ID was sent but not recognised — always reject
+      session_validation <- validate_session_id_header(req)
+      if (!isTRUE(session_validation)) {
+        return(session_validation)
+      }
+    }
+    # Otherwise (no session ID header, or version < 2025-06-18): let it through
+  }
+
+  result <- handle_http_request_message(data, req)
+
+  headers <- list("Content-Type" = "application/json")
+
+  # Return the Mcp-Session-Id header on initialize responses so the client
+  # can include it on subsequent requests.
+  session_id <- attr(result, "mcp_session_id")
+  if (!is.null(session_id)) {
+    headers[["Mcp-Session-Id"]] <- session_id
+    attr(result, "mcp_session_id") <- NULL
+  }
 
   list(
     status = 200L,
-    headers = list("Content-Type" = "application/json"),
+    headers = headers,
     body = to_json(result)
   )
 }
@@ -294,9 +360,20 @@ handle_http_notification_or_response <- function(data) {
   NULL
 }
 
-handle_http_request_message <- function(data) {
+handle_http_request_message <- function(data, req) {
   if (data$method == "initialize") {
-    return(jsonrpc_response(data$id, capabilities()))
+    client_version <- data$params$protocolVersion %||% latest_protocol_version
+    negotiated <- negotiate_protocol_version(client_version)
+    # The server always generates a session ID for internal tracking.
+    # It is only returned to the client (via response header) when the
+    # negotiated version requires it (>= 2025-06-18).
+    session_id <- nanonext::random(n = 16L)
+    set_http_protocol_version(session_id, negotiated)
+    result <- jsonrpc_response(data$id, capabilities(negotiated))
+    if (protocol_version_gte(negotiated, "2025-06-18")) {
+      attr(result, "mcp_session_id") <- session_id
+    }
+    return(result)
   } else if (data$method == "tools/list") {
     return(jsonrpc_response(
       data$id,
@@ -365,7 +442,10 @@ handle_message_from_client <- function(line) {
   # If we made it here, it's valid JSON
 
   if (data$method == "initialize") {
-    res <- jsonrpc_response(data$id, capabilities())
+    client_version <- data$params$protocolVersion %||% latest_protocol_version
+    negotiated <- negotiate_protocol_version(client_version)
+    set_stdio_protocol_version(negotiated)
+    res <- jsonrpc_response(data$id, capabilities(negotiated))
     cat_json(res)
   } else if (data$method == "tools/list") {
     res <- jsonrpc_response(
@@ -438,9 +518,9 @@ cat_json <- function(x) {
   nanonext::write_stdout(to_json(x))
 }
 
-capabilities <- function() {
-  list(
-    protocolVersion = "2025-06-18",
+capabilities <- function(protocol_version = latest_protocol_version) {
+  res <- list(
+    protocolVersion = protocol_version,
     capabilities = list(
       # logging = named_list(),
       prompts = named_list(
@@ -457,9 +537,15 @@ capabilities <- function() {
     serverInfo = list(
       name = "R mcptools server",
       version = "0.0.1"
-    ),
-    instructions = "This provides information about a running R session."
+    )
   )
+
+  # `instructions` was introduced in protocol version 2025-03-26
+  if (protocol_version_gte(protocol_version, "2025-03-26")) {
+    res$instructions <- "This provides information about a running R session."
+  }
+
+  res
 }
 
 tool_as_json <- function(tool) {

--- a/R/server.R
+++ b/R/server.R
@@ -230,11 +230,15 @@ handle_http_request <- function(req) {
   if (req$REQUEST_METHOD == "POST") {
     return(handle_http_post(req))
   } else if (req$REQUEST_METHOD == "GET") {
-    return(handle_http_get(req))
+    return(list(
+      status = 405L,
+      headers = list("Allow" = "POST"),
+      body = "SSE streaming not yet implemented"
+    ))
   } else {
     return(list(
       status = 405L,
-      headers = list("Allow" = "GET, POST"),
+      headers = list("Allow" = "POST"),
       body = "Method Not Allowed"
     ))
   }
@@ -278,24 +282,31 @@ handle_http_post <- function(req) {
     ))
   }
 
+  response <- function(status_code, result) {
+    list(
+      status = status_code,
+      headers = list(
+        "Content-Type" = "application/json",
+        "Mcp-Session-Id" = session_id
+      ),
+      body = to_json(result)
+    )
+  }
+
+  ## Initialize the session and negotiate protocol version
   if (identical(data$method, "initialize")) {
     negotiated_protocol_version <-
       negotiate_protocol_version(data$params$protocolVersion)
     session_id <- nanonext::random(n = 16L)
     set_http_protocol_version(session_id, negotiated_protocol_version)
-    return(list(
-      status = 200L,
-      headers = list(
-        "Content-Type" = "application/json",
-        "Mcp-Session-Id" = session_id
-      ),
-      body = to_json(jsonrpc_response(
-        data$id,
-        capabilities(negotiated_protocol_version, the$server_instructions)
-      ))
-    ))
+    result <- jsonrpc_response(
+      data$id,
+      capabilities(negotiated_protocol_version, the$server_instructions)
+    )
+    return(response(200L, result))
   }
 
+  ## Validate session and protocol version for subsequent requests
   session_id <- req$HTTP_MCP_SESSION_ID
   protocol_version_header <- req$HTTP_MCP_PROTOCOL_VERSION
   negotiated_protocol_version <- get_http_protocol_version(session_id)
@@ -306,37 +317,26 @@ handle_http_post <- function(req) {
     protocol_version_header
   )
   if (!is.null(header_error)) {
-    return(list(
-      status = 400L,
-      headers = list(
-        "Content-Type" = "application/json",
-        "Mcp-Session-Id" = session_id
-      ),
-      body = to_json(jsonrpc_response(
-        id = data$id,
-        error = list(code = -32600, message = header_error)
-      ))
-    ))
+    result <- jsonrpc_response(
+      id = data$id,
+      error = list(code = -32600, message = header_error)
+    )
+    return(response(400L, result))
   }
 
+  ## If we made it here, the session and protocol version are valid.
+  ## Handle the request.
   result <- handle_http_request_message(data)
+  if (!is.null(result)) {
+    return(response(200L, result))
+  }
 
-  list(
-    status = 200L,
-    headers = list(
-      "Content-Type" = "application/json",
-      "Mcp-Session-Id" = session_id
-    ),
-    body = to_json(result)
+  ## No handler for the MCP method was found.
+  result <- jsonrpc_response(
+    data$id,
+    error = list(code = -32601, message = "Method not found")
   )
-}
-
-handle_http_get <- function(req) {
-  list(
-    status = 405L,
-    headers = list("Content-Type" = "text/plain"),
-    body = "SSE streaming not yet implemented"
-  )
+  return(response(404L, result))
 }
 
 handle_http_request_message <- function(data) {
@@ -347,31 +347,25 @@ handle_http_request_message <- function(data) {
     ))
   } else if (data$method == "tools/call") {
     tool_name <- data$params$name
-    if (
-      !the$sessions_enabled ||
-        tool_name %in% c("list_r_sessions", "select_r_session") ||
-        !nanonext::stat(the$server_socket, "pipes")
-    ) {
+    if (!the$sessions_enabled ||
+          tool_name %in% c("list_r_sessions", "select_r_session") ||
+          !nanonext::stat(the$server_socket, "pipes")) {
+      ## Execute the tool call in the server.
       prepared <- append_tool_fn(data)
       if (inherits(prepared, "jsonrpc_error")) {
         return(prepared)
       }
       return(execute_tool_call(prepared))
     } else {
+      ## Forward the tool call to the session.
       prepared <- append_tool_fn(data)
       if (inherits(prepared, "jsonrpc_error")) {
         return(prepared)
       }
-
       nanonext::send(the$server_socket, prepared, mode = "serial")
       response_raw <- nanonext::recv(the$server_socket, mode = "character")
       return(jsonlite::parse_json(response_raw))
     }
-  } else {
-    return(jsonrpc_response(
-      data$id,
-      error = list(code = -32601, message = "Method not found")
-    ))
   }
 }
 

--- a/R/server.R
+++ b/R/server.R
@@ -276,60 +276,6 @@ handle_http_post <- function(req) {
     ))
   }
 
-  session_id <- req$HTTP_MCP_SESSION_ID
-  protocol_version_header <- req$HTTP_MCP_PROTOCOL_VERSION
-  negotiated_protocol_version <- get_http_protocol_version(session_id)
-
-  if (!is.null(protocol_version_header) &&
-        protocol_version_gte(protocol_version_header, "2025-06-18")) {
-    ## For protocol versions >= 2025-06-18, both headers are required on all requests
-    if (is.null(session_id)) {
-      return(list(
-        status = 400L,
-        headers = list("Content-Type" = "application/json"),
-        body = to_json(list(
-          jsonrpc = "2.0",
-          error = list(
-            code = -32600,
-            message = "Missing required Mcp-Session-Id header"
-          )
-        ))
-      ))
-    } else {
-      if (is.null(negotiated_protocol_version)) {
-        return(list(
-          status = 404L,
-          headers = list("Content-Type" = "application/json"),
-          body = to_json(list(
-            jsonrpc = "2.0",
-            error = list(
-              code = -32600,
-              message = "Unknown or expired session ID"
-            )
-          ))
-        ))
-      } else if (!identical(negotiated_protocol_version, protocol_version_header)) {
-        return(list(
-          status = 400L,
-          headers = list("Content-Type" = "application/json"),
-          body = to_json(list(
-            jsonrpc = "2.0",
-            error = list(
-              code = -32600,
-              message = "Mcp-Protocol-Version header does not match negotiated protocol version for this session"
-            )
-          ))
-        ))
-      }
-    }
-  }
-
-  # Validate Mcp-Session-Id and MCP-Protocol-Version headers on non-initialize
-
-  # requests. Per spec (from 2025-06-18), the client MUST include both on
-  # subsequent HTTP requests. For older protocol versions we are permissive:
-  # if the client sends a session ID we verify it, but we do not require either
-  # header to be present.
   if (identical(data$method, "initialize")) {
     negotiated_protocol_version <-
       negotiate_protocol_version(data$params$protocolVersion)
@@ -348,11 +294,37 @@ handle_http_post <- function(req) {
     ))
   }
 
+  session_id <- req$HTTP_MCP_SESSION_ID
+  protocol_version_header <- req$HTTP_MCP_PROTOCOL_VERSION
+  negotiated_protocol_version <- get_http_protocol_version(session_id)
+
+  header_error <- validate_request_headers(
+    session_id,
+    negotiated_protocol_version,
+    protocol_version_header
+  )
+  if (!is.null(header_error)) {
+    return(list(
+      status = 400L,
+      headers = list(
+        "Content-Type" = "application/json",
+        "Mcp-Session-Id" = session_id
+      ),
+      body = to_json(jsonrpc_response(
+        id = data$id,
+        error = list(code = -32600, message = header_error)
+      ))
+    ))
+  }
+
   result <- handle_http_request_message(data)
 
   list(
     status = 200L,
-    headers = list("Content-Type" = "application/json"),
+    headers = list(
+      "Content-Type" = "application/json",
+      "Mcp-Session-Id" = session_id
+    ),
     body = to_json(result)
   )
 }

--- a/R/server.R
+++ b/R/server.R
@@ -141,14 +141,18 @@ mcp_server <- function(
   type = c("stdio", "http"),
   host = "127.0.0.1",
   port = as.integer(Sys.getenv("MCPTOOLS_PORT", "8080")),
-  session_tools = TRUE
+  session_tools = TRUE,
+  instructions = NULL
 ) {
   check_not_interactive()
   type <- rlang::arg_match(type)
 
   nanonext::reap(the$session_socket) # in case session was started in .Rprofile
   the$sessions_enabled <- isTRUE(session_tools)
-  set_server_tools(tools, session_tools = the$sessions_enabled)
+  set_server_tools(tools,
+    session_tools = the$sessions_enabled,
+    instructions = instructions
+  )
 
   switch(
     type,
@@ -362,14 +366,16 @@ handle_http_notification_or_response <- function(data) {
 
 handle_http_request_message <- function(data, req) {
   if (data$method == "initialize") {
-    client_version <- data$params$protocolVersion %||% latest_protocol_version
-    negotiated <- negotiate_protocol_version(client_version)
+    negotiated <- negotiate_protocol_version(data$params$protocolVersion)
     # The server always generates a session ID for internal tracking.
     # It is only returned to the client (via response header) when the
     # negotiated version requires it (>= 2025-06-18).
     session_id <- nanonext::random(n = 16L)
     set_http_protocol_version(session_id, negotiated)
-    result <- jsonrpc_response(data$id, capabilities(negotiated))
+    result <- jsonrpc_response(
+      data$id,
+      capabilities(negotiated, the$server_instructions)
+    )
     if (protocol_version_gte(negotiated, "2025-06-18")) {
       attr(result, "mcp_session_id") <- session_id
     }
@@ -443,10 +449,12 @@ handle_message_from_client <- function(line) {
   # If we made it here, it's valid JSON
 
   if (data$method == "initialize") {
-    client_version <- data$params$protocolVersion %||% latest_protocol_version
-    negotiated <- negotiate_protocol_version(client_version)
+    negotiated <- negotiate_protocol_version(data$params$protocolVersion)
     set_stdio_protocol_version(negotiated)
-    res <- jsonrpc_response(data$id, capabilities(negotiated))
+    res <- jsonrpc_response(
+      data$id,
+      capabilities(negotiated, the$server_instructions)
+    )
     cat_json(res)
   } else if (data$method == "tools/list") {
     res <- jsonrpc_response(
@@ -455,7 +463,6 @@ handle_message_from_client <- function(line) {
         tools = get_mcptools_tools_as_json()
       )
     )
-
     cat_json(res)
   } else if (data$method == "tools/call") {
     tool_name <- data$params$name
@@ -519,11 +526,11 @@ cat_json <- function(x) {
   nanonext::write_stdout(to_json(x))
 }
 
-capabilities <- function(protocol_version = latest_protocol_version) {
+capabilities <- function(protocol_version = latest_protocol_version,
+                         instructions = NULL) {
   res <- list(
     protocolVersion = protocol_version,
     capabilities = list(
-      # logging = named_list(),
       prompts = named_list(
         listChanged = FALSE
       ),
@@ -539,7 +546,7 @@ capabilities <- function(protocol_version = latest_protocol_version) {
       name = "R mcptools server",
       version = as.character(packageVersion("mcptools"))
     ),
-    instructions = "This provides information about a running R session."
+    instructions = instructions
   )
 
   res

--- a/R/server.R
+++ b/R/server.R
@@ -470,7 +470,7 @@ handle_message_from_client <- function(line) {
     ) {
       handle_request(data)
     } else {
-      result <- forward_request(data)
+      forward_request(data)
     }
   } else if (is.null(data$id)) {
     # If there is no `id` in the request, then this is a notification and the
@@ -537,14 +537,10 @@ capabilities <- function(protocol_version = latest_protocol_version) {
     ),
     serverInfo = list(
       name = "R mcptools server",
-      version = "0.0.1"
-    )
+      version = as.character(packageVersion("mcptools"))
+    ),
+    instructions = "This provides information about a running R session."
   )
-
-  # `instructions` was introduced in protocol version 2025-03-26
-  if (protocol_version_gte(protocol_version, "2025-03-26")) {
-    res$instructions <- "This provides information about a running R session."
-  }
 
   res
 }
@@ -557,7 +553,7 @@ tool_as_json <- function(tool) {
   # This field is present but shouldn't be
   inputSchema$description <- NULL
   if (is.null(inputSchema$properties)) {
-    inputSchema$properties <- structure(list(), names = character())
+    inputSchema$properties <- named_list()
   }
 
   list(

--- a/R/server.R
+++ b/R/server.R
@@ -437,6 +437,7 @@ handle_message_from_client <- function(line) {
       data$id,
       error = list(code = -32600, message = "Invalid Request")
     ))
+    return()
   }
 
   # If we made it here, it's valid JSON

--- a/R/tools.R
+++ b/R/tools.R
@@ -2,11 +2,14 @@ set_server_tools <- function(
   x,
   session_tools = TRUE,
   x_arg = caller_arg(x),
-  call = caller_env()
+  call = caller_env(),
+  instructions = NULL
 ) {
   if (is.null(x)) {
     if (session_tools) {
       the$server_tools <- c(list(list_r_sessions_tool, select_r_session_tool))
+      the$server_instructions <- instructions %||%
+        "This provides information about running R sessions."
       return()
     } else {
       cli::cli_abort("No tools selected to serve.", call = call)
@@ -66,6 +69,11 @@ set_server_tools <- function(
         select_r_session_tool
       )
     )
+    the$server_instructions <- instructions %||%
+      "This provides information about running R sessions and executes tools in R."
+  } else {
+    the$server_instructions <- instructions %||%
+      "This provides tools executed in R."
   }
   the$server_tools <- x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,8 +15,7 @@ jsonrpc_response <- function(id, result = NULL, error = NULL) {
 named_list <- function(...) {
   res <- list(...)
   if (length(res) == 0) {
-    # A way of creating an empty named list
-    res <- list(a = 1)[0]
+    res <- structure(list(), names = character())
   }
   res
 }

--- a/inst/example-config-remote.json
+++ b/inst/example-config-remote.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "mcp-remote",
-        "http://localhost:8080"
+        "http://localhost:8087"
       ]
     }
   }

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -12,7 +12,8 @@ mcp_server(
   type = c("stdio", "http"),
   host = "127.0.0.1",
   port = as.integer(Sys.getenv("MCPTOOLS_PORT", "8080")),
-  session_tools = TRUE
+  session_tools = TRUE,
+  instructions = NULL
 )
 
 mcp_session()
@@ -42,6 +43,9 @@ for stdio transport.}
 tools (\code{list_r_sessions}, \code{select_r_session}) that work with
 \code{mcp_session()}. Defaults to \code{TRUE}. Note that the tools to interface with
 sessions are still first routed through the \code{mcp_server()}.}
+
+\item{instructions}{Optional character string with custom server instructions
+included in the capabilities response sent to clients.}
 }
 \value{
 \code{mcp_server()} and \code{mcp_session()} are both called primarily for their

--- a/tests/testthat/_snaps/client.md
+++ b/tests/testthat/_snaps/client.md
@@ -36,5 +36,5 @@
     Condition
       Error in `mcp_tools()`:
       ! The command `Rscript` failed with the following error:
-      x Error: intentional error. Execution halted
+      x Error: intentional error Execution halted
 

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -90,11 +90,12 @@ test_that("mcp_tools() returns mcpServers when valid", {
 test_that("mcp_tools() errors informatively when process exits", {
   skip_on_cran()
   skip_on_ci()
+  rscript_path <- file.path(R.home("bin"), "Rscript")
 
   config <- list(
     mcpServers = list(
       "test" = list(
-        command = "Rscript",
+        command = rscript_path,
         args = c("-e", "stop('intentional error')")
       )
     )
@@ -103,5 +104,7 @@ test_that("mcp_tools() errors informatively when process exits", {
   tmpfile <- withr::local_tempfile(fileext = ".json")
   jsonlite::write_json(config, tmpfile, auto_unbox = TRUE)
 
-  expect_snapshot(error = TRUE, mcp_tools(tmpfile))
+  expect_snapshot(error = TRUE, mcp_tools(tmpfile), transform = function(x) {
+    gsub(rscript_path, "Rscript", x, fixed = TRUE)
+  })
 })

--- a/tests/testthat/test-protocol-version.R
+++ b/tests/testthat/test-protocol-version.R
@@ -1,0 +1,268 @@
+skip_if(is_fedora())
+
+# -- negotiate_protocol_version ------------------------------------------------
+
+test_that("negotiate_protocol_version returns client version when supported", {
+  expect_equal(negotiate_protocol_version("2024-11-05"), "2024-11-05")
+  expect_equal(negotiate_protocol_version("2025-03-26"), "2025-03-26")
+  expect_equal(negotiate_protocol_version("2025-06-18"), "2025-06-18")
+  expect_equal(negotiate_protocol_version("2025-11-25"), "2025-11-25")
+})
+
+test_that("negotiate_protocol_version returns latest for unsupported version", {
+  expect_equal(
+    negotiate_protocol_version("2099-01-01"),
+    latest_protocol_version
+  )
+  expect_equal(
+    negotiate_protocol_version("not-a-version"),
+    latest_protocol_version
+  )
+})
+
+# -- per-transport version storage ---------------------------------------------
+
+test_that("stdio protocol version storage works", {
+  withr::defer(the$negotiated_protocol_version <- NULL)
+
+  set_stdio_protocol_version("2025-03-26")
+  expect_equal(get_stdio_protocol_version(), "2025-03-26")
+})
+
+test_that("get_stdio_protocol_version defaults to latest when unset", {
+  withr::defer(the$negotiated_protocol_version <- NULL)
+
+  the$negotiated_protocol_version <- NULL
+  expect_equal(get_stdio_protocol_version(), latest_protocol_version)
+})
+
+test_that("http protocol version storage works per-session", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  set_http_protocol_version("session-a", "2024-11-05")
+  set_http_protocol_version("session-b", "2025-06-18")
+
+  expect_equal(get_http_protocol_version("session-a"), "2024-11-05")
+  expect_equal(get_http_protocol_version("session-b"), "2025-06-18")
+  expect_null(get_http_protocol_version("session-c"))
+})
+
+# -- version comparison helpers ------------------------------------------------
+
+test_that("protocol_version_gte works", {
+  expect_true(protocol_version_gte("2025-06-18", "2025-03-26"))
+  expect_true(protocol_version_gte("2025-06-18", "2025-06-18"))
+  expect_false(protocol_version_gte("2024-11-05", "2025-03-26"))
+})
+
+test_that("protocol_version_lt works", {
+  expect_true(protocol_version_lt("2024-11-05", "2025-03-26"))
+  expect_false(protocol_version_lt("2025-06-18", "2025-06-18"))
+  expect_false(protocol_version_lt("2025-11-25", "2025-03-26"))
+})
+
+# -- capabilities --------------------------------------------------------------
+
+test_that("capabilities uses supplied protocol version", {
+  res <- capabilities("2025-11-25")
+  expect_equal(res$protocolVersion, "2025-11-25")
+
+  res <- capabilities("2024-11-05")
+  expect_equal(res$protocolVersion, "2024-11-05")
+})
+
+test_that("capabilities defaults to latest protocol version", {
+  res <- capabilities()
+  expect_equal(res$protocolVersion, latest_protocol_version)
+})
+
+test_that("capabilities includes instructions for versions >= 2025-03-26", {
+  res <- capabilities("2025-03-26")
+  expect_true(!is.null(res$instructions))
+
+  res <- capabilities("2025-06-18")
+  expect_true(!is.null(res$instructions))
+
+  res <- capabilities("2025-11-25")
+  expect_true(!is.null(res$instructions))
+})
+
+test_that("capabilities omits instructions for version 2024-11-05", {
+  res <- capabilities("2024-11-05")
+  expect_null(res$instructions)
+})
+
+test_that("capabilities always includes required fields", {
+  for (version in supported_protocol_versions) {
+    res <- capabilities(version)
+    expect_true(!is.null(res$protocolVersion))
+    expect_true(!is.null(res$capabilities))
+    expect_true(!is.null(res$serverInfo))
+    expect_true(!is.null(res$capabilities$tools))
+    expect_equal(res$serverInfo$name, "R mcptools server")
+  }
+})
+
+# -- validate_protocol_version_header -----------------------------------------
+
+test_that("validate_protocol_version_header accepts supported versions", {
+  for (version in supported_protocol_versions) {
+    req <- list(HTTP_MCP_PROTOCOL_VERSION = version)
+    expect_true(validate_protocol_version_header(req))
+  }
+})
+
+test_that("validate_protocol_version_header rejects missing header", {
+  req <- list()
+  result <- validate_protocol_version_header(req)
+  expect_false(isTRUE(result))
+  expect_equal(result$status, 400L)
+})
+
+test_that("validate_protocol_version_header rejects unsupported version", {
+  req <- list(HTTP_MCP_PROTOCOL_VERSION = "2099-01-01")
+  result <- validate_protocol_version_header(req)
+  expect_false(isTRUE(result))
+  expect_equal(result$status, 400L)
+})
+
+# -- validate_session_id_header ------------------------------------------------
+
+test_that("validate_session_id_header accepts known session", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  set_http_protocol_version("test-session-abc", "2025-06-18")
+
+  req <- list(HTTP_MCP_SESSION_ID = "test-session-abc")
+  expect_true(validate_session_id_header(req))
+})
+
+test_that("validate_session_id_header rejects missing header", {
+  req <- list()
+  result <- validate_session_id_header(req)
+  expect_false(isTRUE(result))
+  expect_equal(result$status, 400L)
+})
+
+test_that("validate_session_id_header rejects unknown session", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  req <- list(HTTP_MCP_SESSION_ID = "nonexistent-session")
+  result <- validate_session_id_header(req)
+  expect_false(isTRUE(result))
+  expect_equal(result$status, 404L)
+})
+
+# -- version-gated header enforcement in handle_http_post ----------------------
+# These tests verify the server's permissive behaviour: session ID and protocol
+# version headers are only *required* for protocol versions >= 2025-06-18.
+
+test_that("handle_http_post enforces headers for >= 2025-06-18 sessions", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  set_http_protocol_version("session-new", "2025-06-18")
+
+  # Valid session ID but missing MCP-Protocol-Version → 400
+  req_no_version <- list(
+    REQUEST_METHOD = "POST",
+    HTTP_MCP_SESSION_ID = "session-new",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+    })
+  )
+  result <- handle_http_post(req_no_version)
+  expect_equal(result$status, 400L)
+})
+
+test_that("handle_http_post is permissive for < 2025-06-18 sessions", {
+  withr::defer(the$http_protocol_versions <- NULL)
+  withr::defer(the$server_tools <- NULL)
+  the$sessions_enabled <- FALSE
+  set_server_tools(list(ellmer::tool(
+    function() "hello", "A test tool", name = "test_tool"
+  )), session_tools = FALSE)
+
+  set_http_protocol_version("session-old", "2024-11-05")
+
+  # Request with valid old-version session ID, no protocol version header → OK
+  req <- list(
+    REQUEST_METHOD = "POST",
+    HTTP_MCP_SESSION_ID = "session-old",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+    })
+  )
+  result <- handle_http_post(req)
+  expect_equal(result$status, 200L)
+})
+
+test_that("handle_http_post allows requests with no session header for old clients", {
+  withr::defer(the$http_protocol_versions <- NULL)
+  withr::defer(the$server_tools <- NULL)
+  the$sessions_enabled <- FALSE
+  set_server_tools(list(ellmer::tool(
+    function() "hello", "A test tool", name = "test_tool"
+  )), session_tools = FALSE)
+
+  # No Mcp-Session-Id header at all (old client that never got one) → OK
+  req <- list(
+    REQUEST_METHOD = "POST",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+    })
+  )
+  result <- handle_http_post(req)
+  expect_equal(result$status, 200L)
+})
+
+test_that("handle_http_post rejects unknown session ID regardless of version", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  # A session ID that doesn't map to anything → 404
+  req <- list(
+    REQUEST_METHOD = "POST",
+    HTTP_MCP_SESSION_ID = "totally-bogus",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+    })
+  )
+  result <- handle_http_post(req)
+  expect_equal(result$status, 404L)
+})
+
+test_that("handle_http_post notification path is permissive for old versions", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  set_http_protocol_version("session-old-notif", "2025-03-26")
+
+  # Notification with old-version session ID, no protocol version → 202
+
+  req <- list(
+    REQUEST_METHOD = "POST",
+    HTTP_MCP_SESSION_ID = "session-old-notif",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","method":"some/notification"}')
+    })
+  )
+  result <- handle_http_post(req)
+  expect_equal(result$status, 202L)
+})
+
+test_that("handle_http_post notification path enforces headers for >= 2025-06-18", {
+  withr::defer(the$http_protocol_versions <- NULL)
+
+  set_http_protocol_version("session-new-notif", "2025-06-18")
+
+  # Notification without session ID header for a >= 2025-06-18 session
+  # The server can't know the version without the session ID, so it lets it
+
+  # through (permissive when no session ID is present)
+  req_no_header <- list(
+    REQUEST_METHOD = "POST",
+    rook.input = list(read = function() {
+      charToRaw('{"jsonrpc":"2.0","method":"some/notification"}')
+    })
+  )
+  result <- handle_http_post(req_no_header)
+  expect_equal(result$status, 202L)
+})

--- a/tests/testthat/test-protocol-version.R
+++ b/tests/testthat/test-protocol-version.R
@@ -76,20 +76,12 @@ test_that("capabilities defaults to latest protocol version", {
   expect_equal(res$protocolVersion, latest_protocol_version)
 })
 
-test_that("capabilities includes instructions for versions >= 2025-03-26", {
+test_that("capabilities includes proper instructions", {
   res <- capabilities("2025-03-26")
-  expect_true(!is.null(res$instructions))
-
-  res <- capabilities("2025-06-18")
-  expect_true(!is.null(res$instructions))
-
-  res <- capabilities("2025-11-25")
-  expect_true(!is.null(res$instructions))
-})
-
-test_that("capabilities omits instructions for version 2024-11-05", {
-  res <- capabilities("2024-11-05")
-  expect_null(res$instructions)
+  expect_true(
+    is.null(res$instructions) ||
+      (is.character(res$instructions) && length(res$instructions) == 1L)
+  )
 })
 
 test_that("capabilities always includes required fields", {

--- a/tests/testthat/test-protocol-version.R
+++ b/tests/testthat/test-protocol-version.R
@@ -95,55 +95,6 @@ test_that("capabilities always includes required fields", {
   }
 })
 
-# -- validate_protocol_version_header -----------------------------------------
-
-test_that("validate_protocol_version_header accepts supported versions", {
-  for (version in supported_protocol_versions) {
-    req <- list(HTTP_MCP_PROTOCOL_VERSION = version)
-    expect_true(validate_protocol_version_header(req))
-  }
-})
-
-test_that("validate_protocol_version_header rejects missing header", {
-  req <- list()
-  result <- validate_protocol_version_header(req)
-  expect_false(isTRUE(result))
-  expect_equal(result$status, 400L)
-})
-
-test_that("validate_protocol_version_header rejects unsupported version", {
-  req <- list(HTTP_MCP_PROTOCOL_VERSION = "2099-01-01")
-  result <- validate_protocol_version_header(req)
-  expect_false(isTRUE(result))
-  expect_equal(result$status, 400L)
-})
-
-# -- validate_session_id_header ------------------------------------------------
-
-test_that("validate_session_id_header accepts known session", {
-  withr::defer(the$http_protocol_versions <- NULL)
-
-  set_http_protocol_version("test-session-abc", "2025-06-18")
-
-  req <- list(HTTP_MCP_SESSION_ID = "test-session-abc")
-  expect_true(validate_session_id_header(req))
-})
-
-test_that("validate_session_id_header rejects missing header", {
-  req <- list()
-  result <- validate_session_id_header(req)
-  expect_false(isTRUE(result))
-  expect_equal(result$status, 400L)
-})
-
-test_that("validate_session_id_header rejects unknown session", {
-  withr::defer(the$http_protocol_versions <- NULL)
-
-  req <- list(HTTP_MCP_SESSION_ID = "nonexistent-session")
-  result <- validate_session_id_header(req)
-  expect_false(isTRUE(result))
-  expect_equal(result$status, 404L)
-})
 
 # -- version-gated header enforcement in handle_http_post ----------------------
 # These tests verify the server's permissive behaviour: session ID and protocol
@@ -162,6 +113,7 @@ test_that("handle_http_post enforces headers for >= 2025-06-18 sessions", {
       charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
     })
   )
+  withr::local_options(mcptools.enforce_protocol_headers = TRUE)
   result <- handle_http_post(req_no_version)
   expect_equal(result$status, 400L)
 })
@@ -188,25 +140,6 @@ test_that("handle_http_post is permissive for < 2025-06-18 sessions", {
   expect_equal(result$status, 200L)
 })
 
-test_that("handle_http_post allows requests with no session header for old clients", {
-  withr::defer(the$http_protocol_versions <- NULL)
-  withr::defer(the$server_tools <- NULL)
-  the$sessions_enabled <- FALSE
-  set_server_tools(list(ellmer::tool(
-    function() "hello", "A test tool", name = "test_tool"
-  )), session_tools = FALSE)
-
-  # No Mcp-Session-Id header at all (old client that never got one) → OK
-  req <- list(
-    REQUEST_METHOD = "POST",
-    rook.input = list(read = function() {
-      charToRaw('{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
-    })
-  )
-  result <- handle_http_post(req)
-  expect_equal(result$status, 200L)
-})
-
 test_that("handle_http_post rejects unknown session ID regardless of version", {
   withr::defer(the$http_protocol_versions <- NULL)
 
@@ -219,7 +152,7 @@ test_that("handle_http_post rejects unknown session ID regardless of version", {
     })
   )
   result <- handle_http_post(req)
-  expect_equal(result$status, 404L)
+  expect_equal(result$status, 400L)
 })
 
 test_that("handle_http_post notification path is permissive for old versions", {

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -38,7 +38,7 @@ test_that("roundtrip mcp_server and mcp_tools (http)", {
     command = rscript_binary(),
     args = c(
       "-e",
-      "mcptools::mcp_server(type = 'http', port = 8080)"
+      "mcptools::mcp_server(type = 'http', port = 8087)"
     ),
     stdout = "|",
     stderr = "|"


### PR DESCRIPTION
Summary

- **Add protocol version negotiation** per the MCP specification, supporting versions `2024-11-05`, `2025-03-26`, `2025-06-18`, and `2025-11-25`. The server negotiates the protocol version during initialization and stores it per-session (stdio or HTTP).
- **Refactor HTTP request handling** to centralize header validation logic and unify error responses, making the server flow clearer and more maintainable.
- **Add `instructions` parameter** to `mcp_server()` with adaptive defaults based on whether session tools, user tools, or both are configured.

#### Changes

**Protocol Version Negotiation (`R/protocol-version.R`)**
- New `negotiate_protocol_version()` selects client version if supported, otherwise falls back to latest
- Per-session version storage: `set_/get_stdio_protocol_version()` and `set_/get_http_protocol_version()`
- Version comparison helpers: `protocol_version_gte()`, `protocol_version_lt()`
- Centralized `validate_request_headers()` with version-gated header enforcement for >= `2025-06-18`

**Server Flow Improvements (`R/server.R`)**
- HTTP transport now generates unique session IDs via `nanonext::random()` and returns them via `Mcp-Session-Id` header
- Unified `response()` helper for consistent HTTP responses
- Early return on invalid client requests in stdio handler
- Removed separate `handle_http_get()` and `handle_http_notification_or_response()` in favor of cleaner inline logic

**New Features**
- `instructions` argument for `mcp_server()` with context-aware defaults:
  - Session tools only: "This provides information about running R sessions."
  - User tools + session tools: "This provides information about running R sessions and executes tools in R."
  - User tools only: "This provides tools executed in R."
- Dynamic `serverInfo.version` now reflects actual package version

**Bug Fixes**
- Ensure `properties` field is always present in tool JSON schema output
- Fix `named_list()` to use clean `structure()` approach instead of subset hack
- Improve client error messages by falling back to stdout when stderr is empty

#### Test Plan

- [x] New `test-protocol-version.R` covers version negotiation, per-session storage, comparison helpers, and header validation
- [x] Existing server and client tests updated and passing
- [x] `R CMD check` passes
- [x] Works with btw::btw_mcp_server()