### PR TITLE
fix: ensure inputSchema always includes properties field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mcptools (development version)
 
+* `mcp_server()` now ensures that `inputSchema` always includes a `properties`
+  field, even for tools with no arguments (#91 by @itkonen).
+
 # mcptools 0.2.0
 
 ## Server

--- a/R/server.R
+++ b/R/server.R
@@ -469,6 +469,9 @@ tool_as_json <- function(tool) {
   inputSchema <- compact(as_json(dummy_provider, tool@arguments))
   # This field is present but shouldn't be
   inputSchema$description <- NULL
+  if (is.null(inputSchema$properties)) {
+    inputSchema$properties <- structure(list(), names = character())
+  }
 
   list(
     name = tool@name,

--- a/R/server.R
+++ b/R/server.R
@@ -469,6 +469,9 @@ tool_as_json <- function(tool) {
   inputSchema <- compact(as_json(dummy_provider, tool@arguments))
   # This field is present but shouldn't be
   inputSchema$description <- NULL
+  # compact() drops zero-length elements, so properties gets stripped for
+
+  # no-argument tools. Rather than reworking compact(), patch it here.
   if (is.null(inputSchema$properties)) {
     inputSchema$properties <- structure(list(), names = character())
   }


### PR DESCRIPTION
Tools with no arguments were missing the 'properties' field (dropped by `compact()`), which is required by Github Copilot, causing the HTTP 400 error. I ran in to this problem only when using Anthropic models.  The schema allows 'properties' to be an empty object: https://modelcontextprotocol.io/specification/draft/schema#tool

Fixes https://github.com/posit-dev/mcptools/issues/89