### PR TITLE
feat: add protocol version negotiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mcptools (development version)
 
+* `mcp_server()` now negotiates the protocol version with clients, supporting versions 2024-11-05 through 2025-11-25 (#92 by @itkonen).
+
 # mcptools 0.2.0
 
 ## Server

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -1,0 +1,67 @@
+# Protocol version negotiation
+#
+# The MCP spec requires the server to negotiate a protocol version with the
+# client during initialization. The client sends its preferred version;
+# if the server supports it, the server echoes it back. Otherwise, the server
+# responds with the latest version it supports and the client may disconnect.
+#
+# Adding a new supported version:
+#   1. Append the version string to `supported_protocol_versions` below.
+#   2. If the new version introduces behavioural changes, use
+#      `protocol_version_gte()` / `protocol_version_lt()` guards in the
+#      relevant code paths rather than duplicating implementations.
+
+#' Supported MCP protocol versions, from oldest to newest.
+#' @noRd
+supported_protocol_versions <- c(
+  "2024-11-05",
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25"
+)
+
+#' The latest protocol version supported by this server.
+#' @noRd
+latest_protocol_version <- supported_protocol_versions[
+  length(supported_protocol_versions)
+]
+
+#' Negotiate a protocol version with a client.
+#'
+#' Implements the MCP version negotiation: if the client's requested version
+#' is supported, return it; otherwise return the server's latest version.
+#'
+#' @param client_version Character scalar; the `protocolVersion` from the
+#'   client's `initialize` request.
+#' @return The negotiated version string.
+#' @noRd
+negotiate_protocol_version <- function(client_version) {
+  if (client_version %in% supported_protocol_versions) {
+    client_version
+  } else {
+    latest_protocol_version
+  }
+}
+
+#' Compare the negotiated version against a reference version.
+#'
+#' Useful for version-gating behaviour, e.g.:
+#' ```
+#' if (protocol_version_gte(version, "2025-06-18")) {
+#'   # use new behaviour
+#' }
+#' ```
+#'
+#' @param version   Character scalar; the negotiated version.
+#' @param reference Character scalar; the version to compare against.
+#' @return `TRUE` if `version >= reference` in chronological order.
+#' @noRd
+protocol_version_gte <- function(version, reference) {
+  version >= reference
+}
+
+#' @rdname protocol_version_gte
+#' @noRd
+protocol_version_lt <- function(version, reference) {
+  version < reference
+}

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -1,18 +1,3 @@
-# Protocol version negotiation
-#
-# The MCP spec requires the server to negotiate a protocol version with the
-# client during initialization. The client sends its preferred version;
-# if the server supports it, the server echoes it back. Otherwise, the server
-# responds with the latest version it supports and the client may disconnect.
-#
-# Adding a new supported version:
-#   1. Append the version string to `supported_protocol_versions` below.
-#   2. If the new version introduces behavioural changes, use
-#      `protocol_version_gte()` / `protocol_version_lt()` guards in the
-#      relevant code paths rather than duplicating implementations.
-
-#' Supported MCP protocol versions, from oldest to newest.
-#' @noRd
 supported_protocol_versions <- c(
   "2024-11-05",
   "2025-03-26",
@@ -20,21 +5,10 @@ supported_protocol_versions <- c(
   "2025-11-25"
 )
 
-#' The latest protocol version supported by this server.
-#' @noRd
 latest_protocol_version <- supported_protocol_versions[
   length(supported_protocol_versions)
 ]
 
-#' Negotiate a protocol version with a client.
-#'
-#' Implements the MCP version negotiation: if the client's requested version
-#' is supported, return it; otherwise return the server's latest version.
-#'
-#' @param client_version Character scalar; the `protocolVersion` from the
-#'   client's `initialize` request.
-#' @return The negotiated version string.
-#' @noRd
 negotiate_protocol_version <- function(client_version) {
   if (client_version %in% supported_protocol_versions) {
     client_version
@@ -43,25 +17,10 @@ negotiate_protocol_version <- function(client_version) {
   }
 }
 
-#' Compare the negotiated version against a reference version.
-#'
-#' Useful for version-gating behaviour, e.g.:
-#' ```
-#' if (protocol_version_gte(version, "2025-06-18")) {
-#'   # use new behaviour
-#' }
-#' ```
-#'
-#' @param version   Character scalar; the negotiated version.
-#' @param reference Character scalar; the version to compare against.
-#' @return `TRUE` if `version >= reference` in chronological order.
-#' @noRd
 protocol_version_gte <- function(version, reference) {
   version >= reference
 }
 
-#' @rdname protocol_version_gte
-#' @noRd
 protocol_version_lt <- function(version, reference) {
   version < reference
 }

--- a/R/server.R
+++ b/R/server.R
@@ -296,7 +296,9 @@ handle_http_notification_or_response <- function(data) {
 
 handle_http_request_message <- function(data) {
   if (data$method == "initialize") {
-    return(jsonrpc_response(data$id, capabilities()))
+    client_version <- data$params$protocolVersion %||% latest_protocol_version
+    negotiated <- negotiate_protocol_version(client_version)
+    return(jsonrpc_response(data$id, capabilities(negotiated)))
   } else if (data$method == "tools/list") {
     return(jsonrpc_response(
       data$id,
@@ -365,7 +367,9 @@ handle_message_from_client <- function(line) {
   # If we made it here, it's valid JSON
 
   if (data$method == "initialize") {
-    res <- jsonrpc_response(data$id, capabilities())
+    client_version <- data$params$protocolVersion %||% latest_protocol_version
+    negotiated <- negotiate_protocol_version(client_version)
+    res <- jsonrpc_response(data$id, capabilities(negotiated))
     cat_json(res)
   } else if (data$method == "tools/list") {
     res <- jsonrpc_response(
@@ -438,9 +442,9 @@ cat_json <- function(x) {
   nanonext::write_stdout(to_json(x))
 }
 
-capabilities <- function() {
-  list(
-    protocolVersion = "2025-06-18",
+capabilities <- function(protocol_version = latest_protocol_version) {
+  res <- list(
+    protocolVersion = protocol_version,
     capabilities = list(
       # logging = named_list(),
       prompts = named_list(
@@ -457,9 +461,15 @@ capabilities <- function() {
     serverInfo = list(
       name = "R mcptools server",
       version = "0.0.1"
-    ),
-    instructions = "This provides information about a running R session."
+    )
   )
+
+  # `instructions` was introduced in protocol version 2025-03-26
+  if (protocol_version_gte(protocol_version, "2025-03-26")) {
+    res$instructions <- "This provides information about a running R session."
+  }
+
+  res
 }
 
 tool_as_json <- function(tool) {

--- a/R/server.R
+++ b/R/server.R
@@ -296,6 +296,8 @@ handle_http_notification_or_response <- function(data) {
 
 handle_http_request_message <- function(data) {
   if (data$method == "initialize") {
+    # while protocolVersion is required per spec,
+    # we fall back rather than erroring
     client_version <- data$params$protocolVersion %||% latest_protocol_version
     negotiated <- negotiate_protocol_version(client_version)
     return(jsonrpc_response(data$id, capabilities(negotiated)))
@@ -367,6 +369,8 @@ handle_message_from_client <- function(line) {
   # If we made it here, it's valid JSON
 
   if (data$method == "initialize") {
+    # while protocolVersion is required per spec,
+    # we fall back rather than erroring
     client_version <- data$params$protocolVersion %||% latest_protocol_version
     negotiated <- negotiate_protocol_version(client_version)
     res <- jsonrpc_response(data$id, capabilities(negotiated))

--- a/tests/testthat/test-protocol-version.R
+++ b/tests/testthat/test-protocol-version.R
@@ -1,0 +1,77 @@
+skip_if(is_fedora())
+
+# -- negotiate_protocol_version ------------------------------------------------
+
+test_that("negotiate_protocol_version returns client version when supported", {
+  expect_equal(negotiate_protocol_version("2024-11-05"), "2024-11-05")
+  expect_equal(negotiate_protocol_version("2025-03-26"), "2025-03-26")
+  expect_equal(negotiate_protocol_version("2025-06-18"), "2025-06-18")
+  expect_equal(negotiate_protocol_version("2025-11-25"), "2025-11-25")
+})
+
+test_that("negotiate_protocol_version returns latest for unsupported version", {
+  expect_equal(
+    negotiate_protocol_version("2099-01-01"),
+    latest_protocol_version
+  )
+  expect_equal(
+    negotiate_protocol_version("not-a-version"),
+    latest_protocol_version
+  )
+})
+
+# -- version comparison helpers ------------------------------------------------
+
+test_that("protocol_version_gte works", {
+  expect_true(protocol_version_gte("2025-06-18", "2025-03-26"))
+  expect_true(protocol_version_gte("2025-06-18", "2025-06-18"))
+  expect_false(protocol_version_gte("2024-11-05", "2025-03-26"))
+})
+
+test_that("protocol_version_lt works", {
+  expect_true(protocol_version_lt("2024-11-05", "2025-03-26"))
+  expect_false(protocol_version_lt("2025-06-18", "2025-06-18"))
+  expect_false(protocol_version_lt("2025-11-25", "2025-03-26"))
+})
+
+# -- capabilities --------------------------------------------------------------
+
+test_that("capabilities uses supplied protocol version", {
+  res <- capabilities("2025-11-25")
+  expect_equal(res$protocolVersion, "2025-11-25")
+
+  res <- capabilities("2024-11-05")
+  expect_equal(res$protocolVersion, "2024-11-05")
+})
+
+test_that("capabilities defaults to latest protocol version", {
+  res <- capabilities()
+  expect_equal(res$protocolVersion, latest_protocol_version)
+})
+
+test_that("capabilities includes instructions for versions >= 2025-03-26", {
+  res <- capabilities("2025-03-26")
+  expect_true(!is.null(res$instructions))
+
+  res <- capabilities("2025-06-18")
+  expect_true(!is.null(res$instructions))
+
+  res <- capabilities("2025-11-25")
+  expect_true(!is.null(res$instructions))
+})
+
+test_that("capabilities omits instructions for version 2024-11-05", {
+  res <- capabilities("2024-11-05")
+  expect_null(res$instructions)
+})
+
+test_that("capabilities always includes required fields", {
+  for (version in supported_protocol_versions) {
+    res <- capabilities(version)
+    expect_true(!is.null(res$protocolVersion))
+    expect_true(!is.null(res$capabilities))
+    expect_true(!is.null(res$serverInfo))
+    expect_true(!is.null(res$capabilities$tools))
+    expect_equal(res$serverInfo$name, "R mcptools server")
+  }
+})


### PR DESCRIPTION
This PR implements a minimal MCP protocol version negotiation to support protocol versions 2024-11-05", "2025-03-26",  "2025-06-18", and "2025-11-25". The server now echoes the client's requested version if supported, otherwise responds with the latest version it supports.

Helper functions for the protocol version negotiation were added to R/protocol-version.R

Most methods implemented in the package are identical in all protocol versions. The only exception is the 'instructions' field in 'initialize' which was added in protocol version 2025-03-26.

There's no protocol version validation for HTTP requests after the initialization (possible for >= "2025-06-18"). Session id validation is also not implemented (possible for >= "2025-03-26"). 

I added tests for negotiation, version comparison, and capabilities.