### PR TITLE
Feat/instructions

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -141,14 +141,18 @@ mcp_server <- function(
   type = c("stdio", "http"),
   host = "127.0.0.1",
   port = as.integer(Sys.getenv("MCPTOOLS_PORT", "8080")),
-  session_tools = TRUE
+  session_tools = TRUE,
+  instructions = NULL
 ) {
   check_not_interactive()
   type <- rlang::arg_match(type)
 
   nanonext::reap(the$session_socket) # in case session was started in .Rprofile
   the$sessions_enabled <- isTRUE(session_tools)
-  set_server_tools(tools, session_tools = the$sessions_enabled)
+  set_server_tools(tools,
+    session_tools = the$sessions_enabled,
+    instructions = instructions
+  )
 
   switch(
     type,
@@ -300,7 +304,7 @@ handle_http_request_message <- function(data) {
     # we fall back rather than erroring
     client_version <- data$params$protocolVersion %||% latest_protocol_version
     negotiated <- negotiate_protocol_version(client_version)
-    return(jsonrpc_response(data$id, capabilities(negotiated)))
+    return(jsonrpc_response(data$id, capabilities(negotiated, the$server_instructions)))
   } else if (data$method == "tools/list") {
     return(jsonrpc_response(
       data$id,
@@ -373,7 +377,7 @@ handle_message_from_client <- function(line) {
     # we fall back rather than erroring
     client_version <- data$params$protocolVersion %||% latest_protocol_version
     negotiated <- negotiate_protocol_version(client_version)
-    res <- jsonrpc_response(data$id, capabilities(negotiated))
+    res <- jsonrpc_response(data$id, capabilities(negotiated, the$server_instructions))
     cat_json(res)
   } else if (data$method == "tools/list") {
     res <- jsonrpc_response(
@@ -446,7 +450,8 @@ cat_json <- function(x) {
   nanonext::write_stdout(to_json(x))
 }
 
-capabilities <- function(protocol_version = latest_protocol_version) {
+capabilities <- function(protocol_version = latest_protocol_version,
+                         instructions = NULL) {
   res <- list(
     protocolVersion = protocol_version,
     capabilities = list(
@@ -470,7 +475,7 @@ capabilities <- function(protocol_version = latest_protocol_version) {
 
   # `instructions` was introduced in protocol version 2025-03-26
   if (protocol_version_gte(protocol_version, "2025-03-26")) {
-    res$instructions <- "This provides information about a running R session."
+    res$instructions <- instructions
   }
 
   res

--- a/R/server.R
+++ b/R/server.R
@@ -86,6 +86,10 @@
 #'   tools (`list_r_sessions`, `select_r_session`) that work with
 #'   `mcp_session()`. Defaults to `TRUE`. Note that the tools to interface with
 #'   sessions are still first routed through the `mcp_server()`.
+#' @param instructions An optional character string providing instructions to
+#'   the MCP client about how to use this server and its tools. This is
+#'   included in the `initialize` response and is supported from protocol
+#'   version `2025-03-26` onwards.
 #'
 #' @returns
 #' `mcp_server()` and `mcp_session()` are both called primarily for their

--- a/R/tools.R
+++ b/R/tools.R
@@ -2,11 +2,14 @@ set_server_tools <- function(
   x,
   session_tools = TRUE,
   x_arg = caller_arg(x),
-  call = caller_env()
+  call = caller_env(),
+  instructions = NULL
 ) {
   if (is.null(x)) {
     if (session_tools) {
       the$server_tools <- c(list(list_r_sessions_tool, select_r_session_tool))
+      the$server_instructions <- instructions %||%
+        "This provides information about running R sessions."
       return()
     } else {
       cli::cli_abort("No tools selected to serve.", call = call)
@@ -66,6 +69,11 @@ set_server_tools <- function(
         select_r_session_tool
       )
     )
+    the$server_instructions <- instructions %||%
+      "This provides information about running R sessions and executes tools in R."
+  } else {
+    the$server_instructions <- instructions %||%
+      "This provides tools executed in R."
   }
   the$server_tools <- x
 }

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -12,7 +12,8 @@ mcp_server(
   type = c("stdio", "http"),
   host = "127.0.0.1",
   port = as.integer(Sys.getenv("MCPTOOLS_PORT", "8080")),
-  session_tools = TRUE
+  session_tools = TRUE,
+  instructions = NULL
 )
 
 mcp_session()
@@ -42,6 +43,11 @@ for stdio transport.}
 tools (\code{list_r_sessions}, \code{select_r_session}) that work with
 \code{mcp_session()}. Defaults to \code{TRUE}. Note that the tools to interface with
 sessions are still first routed through the \code{mcp_server()}.}
+
+\item{instructions}{An optional character string providing instructions to
+the MCP client about how to use this server and its tools. This is
+included in the \code{initialize} response and is supported from protocol
+version \code{2025-03-26} onwards.}
 }
 \value{
 \code{mcp_server()} and \code{mcp_session()} are both called primarily for their

--- a/tests/testthat/test-protocol-version.R
+++ b/tests/testthat/test-protocol-version.R
@@ -49,20 +49,30 @@ test_that("capabilities defaults to latest protocol version", {
   expect_equal(res$protocolVersion, latest_protocol_version)
 })
 
-test_that("capabilities includes instructions for versions >= 2025-03-26", {
+test_that("capabilities gates instructions on protocol version", {
+  # introduced in 2025-03-26: absent for older versions
+  res <- capabilities("2024-11-05", instructions = "custom")
+  expect_null(res$instructions)
+
+  # present (as NULL) when no instructions supplied for newer versions
   res <- capabilities("2025-03-26")
-  expect_true(!is.null(res$instructions))
+  expect_null(res$instructions)
 
-  res <- capabilities("2025-06-18")
-  expect_true(!is.null(res$instructions))
+  # user-supplied instructions are passed through for newer versions
+  res <- capabilities("2025-03-26", instructions = "custom")
+  expect_equal(res$instructions, "custom")
 
-  res <- capabilities("2025-11-25")
-  expect_true(!is.null(res$instructions))
+  res <- capabilities("2025-11-25", instructions = "custom")
+  expect_equal(res$instructions, "custom")
 })
 
-test_that("capabilities omits instructions for version 2024-11-05", {
-  res <- capabilities("2024-11-05")
-  expect_null(res$instructions)
+test_that("set_server_tools sets default instructions", {
+  set_server_tools(NULL, session_tools = TRUE)
+  expect_true(is.character(the$server_instructions))
+  expect_true(nchar(the$server_instructions) > 0L)
+
+  set_server_tools(NULL, session_tools = TRUE, instructions = "my instructions")
+  expect_equal(the$server_instructions, "my instructions")
 })
 
 test_that("capabilities always includes required fields", {


### PR DESCRIPTION
This PR introduces an `instructions` parameter to the `mcp_server()` function, enabling users to populate the instructions field in the MCP [InitializeResult](https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult-instructions) message (available since protocol version [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#lifecycle-phases)). This field can provide important context that helps agents use server capabilities more effectively.

The PR also updates the default value of the instructions field to be derived from the server’s configured tools.

Given the wide range of use cases supported by the `mcptools` package, this change allows users to tailor the field to their specific needs.