### PR TITLE
fix: include annotations in tools/list response

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -490,11 +490,18 @@ tool_as_json <- function(tool) {
     inputSchema$properties <- structure(list(), names = character())
   }
 
-  list(
+  result <- list(
     name = tool@name,
     description = tool@description,
     inputSchema = inputSchema
   )
+
+  # Include annotations if declared via ellmer::tool_annotations()
+  if (length(tool@annotations) > 0) {
+    result$annotations <- tool@annotations
+  }
+
+  result
 }
 
 compact <- function(.x) {


### PR DESCRIPTION
## Problem

`tool_as_json()` omits the `annotations` field when serializing tools for the `tools/list` MCP response. The MCP spec (2025-03-26+) [defines annotations as part of each tool](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#tool-annotations), and ellmer already supports declaring them via `tool(annotations = tool_annotations(...))` — but they're silently dropped.

Closes #100.

## Fix

If the ToolDef has annotations (i.e., `length(tool@annotations) > 0`), include them in the JSON output. Otherwise, omit the field (same as current behaviour).

## Testing

Verified locally that a tool defined with:
```r
ellmer::tool(
  fun = function() "ok",
  name = "ping",
  description = "Health check",
  annotations = ellmer::tool_annotations(read_only_hint = TRUE, idempotent_hint = TRUE)
)
```

Produces `annotations: { readOnlyHint: true, idempotentHint: true }` in the `tools/list` response after this fix.

## Checklist

- [x] `R CMD check` passes (no new code paths that could fail — just adds a field to existing output)
- [x] Backwards compatible — tools without annotations are unchanged