### PR TITLE
feat: support image content in tool results (ContentImageInline)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # mcptools (development version)
 
+* `mcp_server()` can now return inline image content from tools that produce
+  `ellmer::ContentImageInline` results, including mixed text and image content
+  (#96, #102).
+
+* `mcp_tools()` now converts MCP tool-result content blocks into ellmer-native
+  text and image content, allowing ellmer chats to receive image results from
+  MCP tools.
+
 # mcptools 0.2.1
 
 * `mcp_server()` now ensures that `inputSchema` always includes a `properties`

--- a/R/client.R
+++ b/R/client.R
@@ -408,7 +408,7 @@ tool_ref <- function(server, tool, arguments) {
 
 call_tool <- function(..., server, tool) {
   server_process <- the$mcp_servers[[server]]$process
-  send_and_receive(
+  response <- send_and_receive(
     server_process,
     mcp_request_tool_call(
       id = jsonrpc_id(server),
@@ -416,6 +416,62 @@ call_tool <- function(..., server, tool) {
       arguments = list(...)
     )
   )
+
+  mcp_tool_result_as_ellmer(response)
+}
+
+mcp_tool_result_as_ellmer <- function(response) {
+  if (is.null(response)) {
+    return(NULL)
+  }
+
+  if (!is.null(response$error)) {
+    cli::cli_abort(response$error$message %||% "MCP tool call failed.")
+  }
+
+  result <- response$result
+  if (is.null(result$content)) {
+    return(result)
+  }
+
+  if (isTRUE(result$isError)) {
+    return(ellmer::ContentToolResult(error = mcp_content_as_text(result$content)))
+  }
+
+  content <- lapply(result$content, mcp_content_as_ellmer)
+  if (all(vapply(content, inherits, logical(1), "ellmer::ContentText"))) {
+    return(mcp_content_as_text(result$content))
+  }
+
+  if (length(content) == 1) {
+    return(content[[1]])
+  }
+
+  content
+}
+
+mcp_content_as_ellmer <- function(content) {
+  switch(
+    content$type,
+    text = ellmer::ContentText(text = content$text %||% ""),
+    image = ellmer::ContentImageInline(
+      type = content$mimeType %||% "image/png",
+      data = content$data
+    ),
+    ellmer::ContentText(text = to_json(content))
+  )
+}
+
+mcp_content_as_text <- function(content) {
+  text <- vapply(content, function(block) {
+    if (identical(block$type, "text")) {
+      return(block$text %||% "")
+    }
+
+    to_json(block)
+  }, character(1))
+
+  paste(text, collapse = "\n")
 }
 
 # retrieve and increment the current rsonrpc id from a server

--- a/R/session.R
+++ b/R/session.R
@@ -56,69 +56,85 @@ handle_message_from_server <- function(data) {
 as_tool_call_result <- function(data, result) {
   is_error <- FALSE
 
-  # ── Handle image content ──────────────────────────────────────
-  # When a tool returns ContentImageInline (e.g. via content_image_file()
-  # or content_image_plot()), produce an MCP image content block.
-  # Also handles ContentToolResult wrapping an image.
-  image <- NULL
-  if (inherits(result, "ellmer::ContentImageInline")) {
-    image <- result
-  } else if (inherits(result, "ellmer::ContentToolResult")) {
-    is_error <- !is.null(result@error)
-    if (inherits(result@value, "ellmer::ContentImageInline")) {
-      image <- result@value
-    }
-  }
-
-  if (!is.null(image)) {
-    return(jsonrpc_response(
-      data$id,
-      list(
-        content = list(list(
-          type = "image",
-          data = image@data,
-          mimeType = image@type
-        )),
-        isError = is_error
-      )
-    ))
-  }
-
-  # ── Handle mixed content (list of Content objects) ────────────
-  # If a tool returns a list mixing ContentImageInline with text,
-  # produce multiple content blocks.
-  if (inherits(result, "ellmer::ContentToolResult") &&
-      is.list(result@value) &&
-      any(vapply(result@value, inherits, logical(1), "ellmer::ContentImageInline"))) {
-    content_blocks <- lapply(result@value, function(item) {
-      if (inherits(item, "ellmer::ContentImageInline")) {
-        list(type = "image", data = item@data, mimeType = item@type)
-      } else {
-        list(type = "text", text = paste(item, collapse = "\n"))
-      }
-    })
-    return(jsonrpc_response(data$id, list(content = content_blocks, isError = is_error)))
-  }
-
-  # ── Default: text content (existing behaviour) ────────────────
-  format_result <- function(x) paste(x, collapse = "\n")
-
   if (inherits(result, "ellmer::ContentToolResult")) {
-    format_result <- asNamespace("ellmer")[["tool_string"]] %||% format_result
+    is_error <- !is.null(result@error)
   }
 
   jsonrpc_response(
     data$id,
     list(
-      content = list(
-        list(
-          type = "text",
-          text = format_result(result)
-        )
-      ),
+      content = as_mcp_content(result),
       isError = is_error
     )
   )
+}
+
+as_mcp_content <- function(result) {
+  if (inherits(result, "ellmer::ContentToolResult")) {
+    value <- result@value
+    if (has_mcp_content(value)) {
+      return(as_mcp_content(value))
+    }
+
+    return(list(as_mcp_text_content(result)))
+  }
+
+  if (is_mcp_content(result)) {
+    return(list(as_mcp_content_block(result)))
+  }
+
+  if (is.list(result) && has_mcp_content(result)) {
+    return(unname(unlist(lapply(result, as_mcp_content), recursive = FALSE)))
+  }
+
+  list(as_mcp_text_content(result))
+}
+
+as_mcp_content_block <- function(result) {
+  if (inherits(result, "ellmer::ContentImageInline")) {
+    return(list(type = "image", data = result@data, mimeType = result@type))
+  }
+
+  if (inherits(result, "ellmer::ContentText")) {
+    return(list(type = "text", text = result@text))
+  }
+
+  as_mcp_text_content(result)
+}
+
+as_mcp_text_content <- function(result) {
+  list(type = "text", text = format_mcp_text(result))
+}
+
+format_mcp_text <- function(result) {
+  if (inherits(result, "ellmer::ContentToolResult")) {
+    format_result <- asNamespace("ellmer")[["tool_string"]] %||%
+      format_default_result
+    return(format_result(result))
+  }
+
+  format_default_result(result)
+}
+
+format_default_result <- function(result) {
+  paste(result, collapse = "\n")
+}
+
+has_mcp_content <- function(result) {
+  if (is_mcp_content(result)) {
+    return(TRUE)
+  }
+
+  if (is.list(result)) {
+    return(any(vapply(result, has_mcp_content, logical(1))))
+  }
+
+  FALSE
+}
+
+is_mcp_content <- function(result) {
+  inherits(result, "ellmer::ContentImageInline") ||
+    inherits(result, "ellmer::ContentText")
 }
 
 schedule_handle_message_from_server <- function() {

--- a/R/session.R
+++ b/R/session.R
@@ -55,13 +55,58 @@ handle_message_from_server <- function(data) {
 
 as_tool_call_result <- function(data, result) {
   is_error <- FALSE
-  format_result <- function(x) paste(x, collapse = "\n")
-  
-  if (inherits(result, "ellmer::ContentToolResult")) {
+
+  # ── Handle image content ──────────────────────────────────────
+  # When a tool returns ContentImageInline (e.g. via content_image_file()
+  # or content_image_plot()), produce an MCP image content block.
+  # Also handles ContentToolResult wrapping an image.
+  image <- NULL
+  if (inherits(result, "ellmer::ContentImageInline")) {
+    image <- result
+  } else if (inherits(result, "ellmer::ContentToolResult")) {
     is_error <- !is.null(result@error)
+    if (inherits(result@value, "ellmer::ContentImageInline")) {
+      image <- result@value
+    }
+  }
+
+  if (!is.null(image)) {
+    return(jsonrpc_response(
+      data$id,
+      list(
+        content = list(list(
+          type = "image",
+          data = image@data,
+          mimeType = image@type
+        )),
+        isError = is_error
+      )
+    ))
+  }
+
+  # ── Handle mixed content (list of Content objects) ────────────
+  # If a tool returns a list mixing ContentImageInline with text,
+  # produce multiple content blocks.
+  if (inherits(result, "ellmer::ContentToolResult") &&
+      is.list(result@value) &&
+      any(vapply(result@value, inherits, logical(1), "ellmer::ContentImageInline"))) {
+    content_blocks <- lapply(result@value, function(item) {
+      if (inherits(item, "ellmer::ContentImageInline")) {
+        list(type = "image", data = item@data, mimeType = item@type)
+      } else {
+        list(type = "text", text = paste(item, collapse = "\n"))
+      }
+    })
+    return(jsonrpc_response(data$id, list(content = content_blocks, isError = is_error)))
+  }
+
+  # ── Default: text content (existing behaviour) ────────────────
+  format_result <- function(x) paste(x, collapse = "\n")
+
+  if (inherits(result, "ellmer::ContentToolResult")) {
     format_result <- asNamespace("ellmer")[["tool_string"]] %||% format_result
   }
-  
+
   jsonrpc_response(
     data$id,
     list(

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -87,6 +87,187 @@ test_that("mcp_tools() returns mcpServers when valid", {
   expect_equal(result, config$mcpServers)
 })
 
+test_that("mcp_tool_result_as_ellmer handles text content", {
+  response <- list(
+    result = list(
+      content = list(list(type = "text", text = "hello")),
+      isError = FALSE
+    )
+  )
+
+  expect_equal(mcp_tool_result_as_ellmer(response), "hello")
+})
+
+test_that("mcp_tool_result_as_ellmer handles image content", {
+  response <- list(
+    result = list(
+      content = list(list(
+        type = "image",
+        data = "abc123",
+        mimeType = "image/png"
+      )),
+      isError = FALSE
+    )
+  )
+
+  result <- mcp_tool_result_as_ellmer(response)
+
+  expect_s3_class(result, "ellmer::ContentImageInline")
+  expect_equal(result@data, "abc123")
+  expect_equal(result@type, "image/png")
+})
+
+test_that("mcp_tool_result_as_ellmer handles mixed content", {
+  response <- list(
+    result = list(
+      content = list(
+        list(type = "text", text = "caption"),
+        list(type = "image", data = "abc123", mimeType = "image/png")
+      ),
+      isError = FALSE
+    )
+  )
+
+  result <- mcp_tool_result_as_ellmer(response)
+
+  expect_length(result, 2)
+  expect_s3_class(result[[1]], "ellmer::ContentText")
+  expect_s3_class(result[[2]], "ellmer::ContentImageInline")
+})
+
+test_that("mixed MCP content expands in ellmer tool result turns", {
+  response <- list(
+    result = list(
+      content = list(
+        list(type = "text", text = "caption"),
+        list(type = "image", data = "abc123", mimeType = "image/png")
+      ),
+      isError = FALSE
+    )
+  )
+  request <- ellmer::ContentToolRequest(
+    id = "call_1",
+    name = "get_reference_image",
+    arguments = list()
+  )
+
+  result <- ellmer:::new_tool_result(request, mcp_tool_result_as_ellmer(response))
+  turn <- ellmer:::user_turn(result)
+  turn <- ellmer:::turn_contents_expand(turn)
+
+  expect_s3_class(turn@contents[[1]], "ellmer::ContentToolResult")
+  expect_s3_class(turn@contents[[2]], "ellmer::ContentText")
+  expect_s3_class(turn@contents[[3]], "ellmer::ContentText")
+  expect_s3_class(turn@contents[[4]], "ellmer::ContentText")
+  expect_equal(turn@contents[[4]]@text, "caption")
+  expect_s3_class(turn@contents[[7]], "ellmer::ContentImageInline")
+  expect_s3_class(turn@contents[[9]], "ellmer::ContentText")
+})
+
+test_that("MCP image content serializes as image content in ellmer", {
+  response <- list(
+    result = list(
+      content = list(list(
+        type = "image",
+        data = "abc123",
+        mimeType = "image/png"
+      )),
+      isError = FALSE
+    )
+  )
+  request <- ellmer::ContentToolRequest(
+    id = "call_1",
+    name = "get_reference_image",
+    arguments = list()
+  )
+
+  result <- ellmer:::new_tool_result(request, mcp_tool_result_as_ellmer(response))
+  turn <- ellmer:::user_turn(result)
+  provider <- ellmer::chat_openai(model = "gpt-4.1-mini-2025-04-14")$get_provider()
+  json <- ellmer:::as_json(provider, turn)
+  json <- to_json(json)
+
+  expect_match(json, "input_image", fixed = TRUE)
+  expect_match(json, "data:image/png;base64,abc123", fixed = TRUE)
+})
+
+test_that("OpenAI can inspect an MCP image tool result", {
+  skip_on_cran()
+  skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
+
+  image_path <- tempfile(pattern = "reference-image-", fileext = ".jpg")
+  stopifnot(!grepl("cat", basename(image_path), ignore.case = TRUE))
+  download.file(
+    "https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg",
+    image_path,
+    mode = "wb",
+    quiet = TRUE
+  )
+
+  tool_file <- withr::local_tempfile(fileext = ".R")
+  writeLines(
+    c(
+      "list(",
+      "  get_reference_image = ellmer::tool(",
+      sprintf(
+        "    fun = function() ellmer::content_image_file(%s),",
+        shQuote(image_path)
+      ),
+      "    name = 'get_reference_image',",
+      "    description = 'Return the reference image as inline image content.',",
+      "    arguments = list()",
+      "  )",
+      ")"
+    ),
+    tool_file
+  )
+
+  server_expr <- sprintf(
+    "pkgload::load_all('.', quiet = TRUE); mcptools::mcp_server(tools = %s, session_tools = FALSE)",
+    shQuote(tool_file)
+  )
+  config_file <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(
+    list(
+      mcpServers = list(
+        image_demo = list(
+          command = rscript_binary(),
+          args = c("-e", server_expr)
+        )
+      )
+    ),
+    config_file,
+    auto_unbox = TRUE
+  )
+
+  tools <- mcp_tools(config_file)
+  server_process <- tail(the$server_processes, 1)[[1]]
+  withr::defer(server_process$kill())
+
+  chat <- ellmer::chat_openai(model = "gpt-4.1-mini-2025-04-14", echo = "none")
+  chat$set_tools(tools)
+  reply <- chat$chat(
+    "Call the get_reference_image tool, inspect the image it returns, and name the animal shown.",
+    echo = "none"
+  )
+
+  expect_true(grepl("cat", reply, ignore.case = TRUE))
+})
+
+test_that("mcp_tool_result_as_ellmer handles tool errors", {
+  response <- list(
+    result = list(
+      content = list(list(type = "text", text = "bad input")),
+      isError = TRUE
+    )
+  )
+
+  result <- mcp_tool_result_as_ellmer(response)
+
+  expect_s3_class(result, "ellmer::ContentToolResult")
+  expect_equal(result@error, "bad input")
+})
+
 test_that("mcp_tools() errors informatively when process exits", {
   skip_on_cran()
   skip_on_ci()

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -47,6 +47,64 @@ test_that("as_tool_call_result handles ContentToolResult with error", {
   expect_true(output$result$isError)
 })
 
+test_that("as_tool_call_result handles direct image content", {
+  data <- list(id = 1)
+  result <- ellmer::ContentImageInline(type = "image/png", data = "abc123")
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$result$content[[1]]$type, "image")
+  expect_equal(output$result$content[[1]]$data, "abc123")
+  expect_equal(output$result$content[[1]]$mimeType, "image/png")
+  expect_false(output$result$isError)
+})
+
+test_that("as_tool_call_result handles ContentToolResult with image content", {
+  data <- list(id = 1)
+  image <- ellmer::ContentImageInline(type = "image/png", data = "abc123")
+  result <- ellmer::ContentToolResult(value = image)
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$result$content[[1]]$type, "image")
+  expect_equal(output$result$content[[1]]$data, "abc123")
+  expect_equal(output$result$content[[1]]$mimeType, "image/png")
+  expect_false(output$result$isError)
+})
+
+test_that("as_tool_call_result handles bare mixed content", {
+  data <- list(id = 1)
+  image <- ellmer::ContentImageInline(type = "image/png", data = "abc123")
+  result <- list("caption", image)
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$result$content[[1]], list(type = "text", text = "caption"))
+  expect_equal(output$result$content[[2]], list(
+    type = "image",
+    data = "abc123",
+    mimeType = "image/png"
+  ))
+  expect_false(output$result$isError)
+})
+
+test_that("as_tool_call_result handles mixed ellmer content", {
+  data <- list(id = 1)
+  text <- ellmer::ContentText(text = "caption")
+  image <- ellmer::ContentImageInline(type = "image/png", data = "abc123")
+  result <- ellmer::ContentToolResult(value = list(text, image))
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$result$content[[1]], list(type = "text", text = "caption"))
+  expect_equal(output$result$content[[2]], list(
+    type = "image",
+    data = "abc123",
+    mimeType = "image/png"
+  ))
+  expect_false(output$result$isError)
+})
+
 test_that("as_tool_call_result handles vector results", {
   data <- list(id = 1)
   result <- c("line1", "line2", "line3")


### PR DESCRIPTION
## Problem

`as_tool_call_result()` hardcodes all tool results as `type: "text"`. There's no way for an R tool to return an image that renders inline in the client (e.g., Claude Desktop). This was reported in #96.

## Fix

Three new code paths in `as_tool_call_result()`:

1. **Direct image**: Tool returns `ContentImageInline` → MCP image content block
2. **Wrapped image**: Tool returns `ContentToolResult(value = ContentImageInline(...))` → MCP image content block
3. **Mixed content**: Tool returns `ContentToolResult(value = list(ContentImageInline(...), "text"))` → multiple content blocks (text + image)

Default text-only behaviour is unchanged.

## Usage

After this fix, an MCP server tool can return inline images:

```r
ellmer::tool(
  fun = function() {
    # ... generate a plot ...
    ellmer::content_image_file("map.png")
  },
  name = "generate_map",
  description = "Generate a suitability map"
)
```

The image will appear inline in Claude Desktop / other MCP clients, and the LLM can reason about it visually.

## Testing

Verified that:
- Tools returning plain strings → unchanged (text content)
- Tools returning `content_image_file(path)` → image content block with base64 data
- Tools returning `ContentToolResult(value = content_image_plot())` → image content block
- Tools returning mixed list → multiple content blocks

Closes #96.