### PR TITLE
support `mcp_server()`s on Posit Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     nanonext (>= 1.6.0),
     processx,
     promises,
-    rlang
+    rlang,
+    yaml
 Suggests: 
     knitr,
     rmarkdown,
@@ -45,4 +46,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mcptools (development version)
 
+* mcptools can now run as a Posit Connect R API engine. Add `_server.yml`
+  with `engine: mcptools`, point `tools` to an `.R` file returning
+  `ellmer::tool()` objects, and deploy with
+  `rsconnect::deployAPI(".", contentCategory = "mcp")`.
+
 * Forwarded `mcp_session()` tool calls now return JSON-RPC errors when the
   selected R session does not respond within two minutes, rather than hanging
   indefinitely. Configure the timeout with the

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,2 +1,5 @@
 the <- new_environment()
 the$server_processes <- list()
+the$http_allowed_origins <- character()
+the$http_trusted_hosts <- character()
+the$http_shared_secret <- NULL

--- a/R/connect.R
+++ b/R/connect.R
@@ -1,0 +1,116 @@
+launch_server <- function(settings, host = NULL, port = NULL, ...) {
+  server_file <- settings
+  config <- read_connect_server_config(server_file)
+  configure_connect_http_security()
+
+  args <- list(
+    tools = config$tools,
+    type = "http",
+    session_tools = config$session_tools
+  )
+
+  if (!is.null(host)) {
+    args$host <- host
+  }
+  if (!is.null(port)) {
+    args$port <- port
+  }
+
+  do.call(mcp_server, args)
+}
+
+read_connect_server_config <- function(server_file, call = caller_env()) {
+  if (!is_string(server_file) || !file.exists(server_file)) {
+    cli::cli_abort(
+      "{.arg server_file} must be a single existing file path.",
+      call = call
+    )
+  }
+
+  config <- yaml::read_yaml(server_file)
+  if (!is.list(config)) {
+    cli::cli_abort(
+      "{.file {basename(server_file)}} must be a YAML mapping.",
+      call = call
+    )
+  }
+
+  engine <- config$engine %||% ""
+  if (!identical(engine, "mcptools")) {
+    cli::cli_abort(
+      "{.file {basename(server_file)}} must specify {.code engine: mcptools}.",
+      call = call
+    )
+  }
+
+  tools <- config$tools %||% NULL
+  if (!is.null(tools)) {
+    tools <- resolve_connect_tools_path(tools, server_file, call = call)
+  }
+
+  session_tools <- config$session_tools %||% FALSE
+  if (
+    !is.logical(session_tools) ||
+      length(session_tools) != 1L ||
+      is.na(session_tools)
+  ) {
+    cli::cli_abort(
+      "{.field session_tools} must be {.code true} or {.code false}.",
+      call = call
+    )
+  }
+
+  list(
+    tools = tools,
+    session_tools = session_tools
+  )
+}
+
+resolve_connect_tools_path <- function(
+  tools,
+  server_file,
+  call = caller_env()
+) {
+  if (!is_string(tools)) {
+    cli::cli_abort(
+      "{.field tools} must be a single file path.",
+      call = call
+    )
+  }
+
+  if (!grepl("\\.r$", tools, ignore.case = TRUE)) {
+    cli::cli_abort(
+      "{.field tools} must point to an {.file .R} file.",
+      call = call
+    )
+  }
+
+  if (!is_absolute_path(tools)) {
+    tools <- file.path(dirname(server_file), tools)
+  }
+
+  if (!file.exists(tools)) {
+    cli::cli_abort(
+      "The {.field tools} file {.file {tools}} does not exist.",
+      call = call
+    )
+  }
+
+  normalizePath(tools, mustWork = TRUE)
+}
+
+configure_connect_http_security <- function() {
+  origin <- connect_server_origin()
+  the$http_allowed_origins <- origin %||% character()
+  the$http_trusted_hosts <- character()
+  invisible()
+}
+
+connect_server_origin <- function() {
+  connect_server <- Sys.getenv("CONNECT_SERVER", "")
+  if (!nzchar(connect_server)) {
+    return(NULL)
+  }
+
+  url_origin(connect_server)
+}

--- a/R/server.R
+++ b/R/server.R
@@ -54,6 +54,34 @@
 #'
 #' The server will listen for HTTP POST requests containing JSON-RPC messages.
 #'
+#' ## Posit Connect
+#'
+#' To deploy an HTTP MCP server to Posit Connect, add a `_server.yml` file to
+#' the project directory:
+#'
+#' ```yaml
+#' engine: mcptools
+#' tools: tools.R
+#' ```
+#'
+#' The `tools` file should return a list of [ellmer::tool()] objects. Deploy
+#' the project as an R API and mark it as MCP content:
+#'
+#' ```r
+#' rsconnect::deployAPI(".", contentCategory = "mcp")
+#' ```
+#'
+#' Use the Connect content URL with `/mcp` appended as the MCP endpoint. For
+#' example, if the content URL is `https://connect.example.com/content/abc123/`,
+#' use `https://connect.example.com/content/abc123/mcp`. mcptools accepts
+#' requests at any path, so the content URL itself also works.
+#' If you cannot set `contentCategory = "mcp"` during deployment, set the MCP
+#' category in Connect after deploying and set minimum processes to at least 1.
+#'
+#' Connect deployments run tools inside the deployed R process by default.
+#' Session discovery with [mcp_session()] is intended for local desktop R
+#' sessions and is disabled by default on Connect.
+#'
 #' **mcp_server() is not intended for interactive use.**
 #'
 #' The server interfaces with the MCP client. If you'd like tools to have access
@@ -201,12 +229,16 @@ mcp_server_http <- function(host = "127.0.0.1", port = 8080) {
 }
 
 handle_http_request <- function(req) {
+  if (!validate_shared_secret(req)) {
+    return(http_forbidden("Invalid shared secret"))
+  }
+
+  if (!validate_host(req)) {
+    return(http_forbidden("Invalid Host"))
+  }
+
   if (!validate_origin(req)) {
-    return(list(
-      status = 403L,
-      headers = list("Content-Type" = "application/json"),
-      body = to_json(list(error = "Invalid Origin"))
-    ))
+    return(http_forbidden("Invalid Origin"))
   }
 
   if (req$REQUEST_METHOD == "POST") {
@@ -222,16 +254,80 @@ handle_http_request <- function(req) {
   }
 }
 
+http_forbidden <- function(error) {
+  list(
+    status = 403L,
+    headers = list("Content-Type" = "application/json"),
+    body = to_json(list(error = error))
+  )
+}
+
+validate_shared_secret <- function(req) {
+  shared_secret <- http_shared_secret()
+  if (!nzchar(shared_secret)) {
+    return(TRUE)
+  }
+
+  header <- req$HTTP_PLUMBER_SHARED_SECRET
+  if (is.null(header)) {
+    return(FALSE)
+  }
+
+  constant_time_equal(header, shared_secret)
+}
+
+http_shared_secret <- function() {
+  first_nonempty_string(
+    the$http_shared_secret,
+    getOption("mcptools.http_shared_secret", NULL),
+    getOption("plumber2.sharedSecret", "")
+  )
+}
+
+validate_host <- function(req) {
+  trusted_hosts <- http_trusted_hosts()
+  if (!length(trusted_hosts)) {
+    return(TRUE)
+  }
+
+  host <- req$HTTP_HOST
+  if (is.null(host)) {
+    return(FALSE)
+  }
+
+  host %in% trusted_hosts
+}
+
+http_trusted_hosts <- function() {
+  unique(c(
+    the$http_trusted_hosts,
+    getOption("mcptools.http_trusted_hosts", character()),
+    split_envvar(Sys.getenv("MCPTOOLS_HTTP_TRUSTED_HOSTS", ""))
+  ))
+}
+
 validate_origin <- function(req) {
   origin <- req$HTTP_ORIGIN
   if (is.null(origin)) {
     return(TRUE)
   }
 
-  parsed <- httr2::url_parse(origin)
+  parsed <- url_parse_or_null(origin)
+  if (is.null(parsed)) {
+    return(FALSE)
+  }
+
   allowed_hosts <- c("localhost", "127.0.0.1", "[::1]")
 
-  return(parsed$hostname %in% allowed_hosts)
+  origin %in% http_allowed_origins() || parsed$hostname %in% allowed_hosts
+}
+
+http_allowed_origins <- function() {
+  unique(c(
+    the$http_allowed_origins,
+    getOption("mcptools.http_allowed_origins", character()),
+    split_envvar(Sys.getenv("MCPTOOLS_HTTP_ALLOWED_ORIGINS", ""))
+  ))
 }
 
 handle_http_post <- function(req) {

--- a/R/server.R
+++ b/R/server.R
@@ -367,9 +367,14 @@ handle_http_post <- function(req) {
 
 handle_http_get <- function(req) {
   list(
-    status = 405L,
+    status = 200L,
     headers = list("Content-Type" = "text/plain"),
-    body = "SSE streaming not yet implemented"
+    body = paste(
+      "mcptools MCP server is running.",
+      "",
+      "Use this URL from an MCP client that supports Streamable HTTP.",
+      sep = "\n"
+    )
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,72 @@ to_json <- function(x, ...) {
   jsonlite::toJSON(x, ..., auto_unbox = TRUE)
 }
 
+is_string <- function(x) {
+  is.character(x) && length(x) == 1L && !is.na(x)
+}
+
+is_absolute_path <- function(path) {
+  grepl("^(/|[A-Za-z]:[/\\\\]|\\\\\\\\)", path)
+}
+
+split_envvar <- function(x) {
+  if (!nzchar(x)) {
+    return(character())
+  }
+
+  trimws(strsplit(x, ",", fixed = TRUE)[[1]])
+}
+
+first_nonempty_string <- function(...) {
+  for (x in list(...)) {
+    if (is_string(x) && nzchar(x)) {
+      return(x)
+    }
+  }
+
+  ""
+}
+
+url_origin <- function(x) {
+  parsed <- url_parse_or_null(x)
+  if (is.null(parsed$scheme) || is.null(parsed$hostname)) {
+    return(NULL)
+  }
+
+  host <- parsed$hostname
+  if (!is.null(parsed$port)) {
+    host <- paste0(host, ":", parsed$port)
+  }
+
+  paste0(parsed$scheme, "://", host)
+}
+
+url_parse_or_null <- function(x) {
+  tryCatch(
+    httr2::url_parse(x),
+    error = function(err) NULL
+  )
+}
+
+constant_time_equal <- function(x, y) {
+  if (!is_string(x) || !is_string(y)) {
+    return(FALSE)
+  }
+
+  x <- as.integer(charToRaw(enc2utf8(x)))
+  y <- as.integer(charToRaw(enc2utf8(y)))
+  n <- max(length(x), length(y))
+  diff <- bitwXor(length(x), length(y))
+
+  for (i in seq_len(n)) {
+    x_i <- if (i <= length(x)) x[[i]] else 0L
+    y_i <- if (i <= length(y)) y[[i]] else 0L
+    diff <- bitwOr(diff, bitwXor(x_i, y_i))
+  }
+
+  identical(diff, 0L)
+}
+
 interactive <- NULL
 
 mcptools_server_log <- function() {

--- a/README.Rmd
+++ b/README.Rmd
@@ -99,6 +99,23 @@ claude mcp add -s "user" r-mcptools -- Rscript -e "mcptools::mcp_server()"
 
 Then, if you'd like models to access variables in specific R sessions, call `mcptools::mcp_session()` in those sessions. (You might include a call to this function in your .Rprofile, perhaps using `usethis::edit_r_profile()`, to automatically register every session you start up.)
 
+To deploy an HTTP MCP server to Posit Connect, add a `_server.yml` file with `engine: mcptools` and a `tools` file:
+
+```yaml
+engine: mcptools
+tools: tools.R
+```
+
+Deploy the directory as an R API and mark it as MCP content:
+
+```r
+rsconnect::deployAPI(".", contentCategory = "mcp")
+```
+
+If the content URL is `https://connect.example.com/content/abc123/`, use `https://connect.example.com/content/abc123/mcp` as the MCP endpoint.
+
+If you cannot set `contentCategory = "mcp"` during deployment, set the MCP category in Connect after deploying and set minimum processes to at least 1.
+
 ### R as an MCP client
 
 mcptools uses the Claude Desktop configuration file format to register third-party MCP servers, as most MCP servers provide setup instructions for Claude Desktop in their documentation. For example, here's what the [official GitHub MCP server](https://github.com/github/github-mcp-server) configuration would look like:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ call to this function in your .Rprofile, perhaps using
 `usethis::edit_r_profile()`, to automatically register every session you
 start up.)
 
+To deploy an HTTP MCP server to Posit Connect, add a `_server.yml` file
+with `engine: mcptools` and a `tools` file:
+
+``` yaml
+engine: mcptools
+tools: tools.R
+```
+
+Deploy the directory as an R API and mark it as MCP content:
+
+``` r
+rsconnect::deployAPI(".", contentCategory = "mcp")
+```
+
+If the content URL is `https://connect.example.com/content/abc123/`, use
+`https://connect.example.com/content/abc123/mcp` as the MCP endpoint.
+
+If you cannot set `contentCategory = "mcp"` during deployment, set the
+MCP category in Connect after deploying and set minimum processes to at
+least 1.
+
 ### R as an MCP client
 
 mcptools uses the Claude Desktop configuration file format to register

--- a/man/mcptools-package.Rd
+++ b/man/mcptools-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Simon Couch \email{simon.couch@posit.co} (\href{https://orcid.org/0000-0001-5676-5107}{ORCID})
   \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0002-1576-2126}{ORCID})
   \item Charlie Gao \email{charlie.gao@posit.co} (\href{https://orcid.org/0000-0002-0750-061X}{ORCID})
 }

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -97,6 +97,33 @@ mcp_server(type = "http", host = "127.0.0.1", port = 9000)
 }\if{html}{\out{</div>}}
 
 The server will listen for HTTP POST requests containing JSON-RPC messages.
+}
+
+\subsection{Posit Connect}{
+
+To deploy an HTTP MCP server to Posit Connect, add a \verb{_server.yml} file to
+the project directory:
+
+\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{engine: mcptools
+tools: tools.R
+}\if{html}{\out{</div>}}
+
+The \code{tools} file should return a list of \code{\link[ellmer:tool]{ellmer::tool()}} objects. Deploy
+the project as an R API and mark it as MCP content:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{rsconnect::deployAPI(".", contentCategory = "mcp")
+}\if{html}{\out{</div>}}
+
+Use the Connect content URL with \verb{/mcp} appended as the MCP endpoint. For
+example, if the content URL is \verb{https://connect.example.com/content/abc123/},
+use \verb{https://connect.example.com/content/abc123/mcp}. mcptools accepts
+requests at any path, so the content URL itself also works.
+If you cannot set \code{contentCategory = "mcp"} during deployment, set the MCP
+category in Connect after deploying and set minimum processes to at least 1.
+
+Connect deployments run tools inside the deployed R process by default.
+Session discovery with \code{\link[=mcp_session]{mcp_session()}} is intended for local desktop R
+sessions and is disabled by default on Connect.
 
 \strong{mcp_server() is not intended for interactive use.}
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -20,3 +20,29 @@ local_protocol_version <- function(
   the$protocol_version <- protocol_version
   invisible(protocol_version)
 }
+
+local_http_security <- function(
+  allowed_origins = character(),
+  trusted_hosts = character(),
+  shared_secret = NULL,
+  env = parent.frame()
+) {
+  old_allowed_origins <- the$http_allowed_origins
+  old_trusted_hosts <- the$http_trusted_hosts
+  old_shared_secret <- the$http_shared_secret
+
+  withr::defer(
+    {
+      the$http_allowed_origins <- old_allowed_origins
+      the$http_trusted_hosts <- old_trusted_hosts
+      the$http_shared_secret <- old_shared_secret
+    },
+    envir = env
+  )
+
+  the$http_allowed_origins <- allowed_origins
+  the$http_trusted_hosts <- trusted_hosts
+  the$http_shared_secret <- shared_secret
+
+  invisible()
+}

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -1,0 +1,146 @@
+skip_if(is_fedora())
+
+test_that("read_connect_server_config reads mcptools server config", {
+  dir <- withr::local_tempdir()
+  tools <- file.path(dir, "tools.R")
+  writeLines("list()", tools)
+
+  server_file <- file.path(dir, "_server.yml")
+  writeLines(
+    c(
+      "engine: mcptools",
+      "tools: tools.R"
+    ),
+    server_file
+  )
+
+  config <- read_connect_server_config(server_file)
+
+  expect_equal(config$tools, normalizePath(tools))
+  expect_false(config$session_tools)
+})
+
+test_that("read_connect_server_config allows explicit session tools", {
+  dir <- withr::local_tempdir()
+  tools <- file.path(dir, "tools.R")
+  writeLines("list()", tools)
+
+  server_file <- file.path(dir, "_server.yml")
+  writeLines(
+    c(
+      "engine: mcptools",
+      "tools: tools.R",
+      "session_tools: true"
+    ),
+    server_file
+  )
+
+  config <- read_connect_server_config(server_file)
+
+  expect_true(config$session_tools)
+})
+
+test_that("read_connect_server_config validates server config", {
+  dir <- withr::local_tempdir()
+  server_file <- file.path(dir, "_server.yml")
+
+  writeLines("engine: plumber2", server_file)
+  expect_error(
+    read_connect_server_config(server_file),
+    "engine: mcptools",
+    fixed = TRUE
+  )
+
+  writeLines(c("engine: mcptools", "tools: missing.R"), server_file)
+  expect_error(
+    read_connect_server_config(server_file),
+    "does not exist",
+    fixed = TRUE
+  )
+
+  writeLines(c("engine: mcptools", "session_tools: maybe"), server_file)
+  expect_error(
+    read_connect_server_config(server_file),
+    "session_tools",
+    fixed = TRUE
+  )
+})
+
+test_that("launch_server calls mcp_server with Connect defaults", {
+  dir <- withr::local_tempdir()
+  tools <- file.path(dir, "tools.R")
+  writeLines("list()", tools)
+
+  server_file <- file.path(dir, "_server.yml")
+  writeLines(
+    c(
+      "engine: mcptools",
+      "tools: tools.R"
+    ),
+    server_file
+  )
+
+  testthat::local_mocked_bindings(
+    mcp_server = function(...) list(...)
+  )
+
+  res <- launch_server(settings = server_file, host = "127.0.0.1", port = 1234L)
+
+  expect_equal(res$tools, normalizePath(tools))
+  expect_equal(res$type, "http")
+  expect_equal(res$host, "127.0.0.1")
+  expect_equal(res$port, 1234L)
+  expect_false(res$session_tools)
+})
+
+test_that("launch_server allows omitted host and port", {
+  dir <- withr::local_tempdir()
+  tools <- file.path(dir, "tools.R")
+  writeLines("list()", tools)
+
+  server_file <- file.path(dir, "_server.yml")
+  writeLines(
+    c(
+      "engine: mcptools",
+      "tools: tools.R"
+    ),
+    server_file
+  )
+
+  testthat::local_mocked_bindings(
+    mcp_server = function(...) list(...)
+  )
+
+  res <- launch_server(settings = server_file, ignored = TRUE)
+
+  expect_equal(res$tools, normalizePath(tools))
+  expect_equal(res$type, "http")
+  expect_null(res$host)
+  expect_null(res$port)
+  expect_false(res$session_tools)
+})
+
+test_that("launch_server allows Connect origin when configured", {
+  dir <- withr::local_tempdir()
+  tools <- file.path(dir, "tools.R")
+  writeLines("list()", tools)
+
+  server_file <- file.path(dir, "_server.yml")
+  writeLines(
+    c(
+      "engine: mcptools",
+      "tools: tools.R"
+    ),
+    server_file
+  )
+
+  withr::local_envvar(CONNECT_SERVER = "https://connect.example.com/rsc")
+  local_http_security(allowed_origins = character())
+  testthat::local_mocked_bindings(
+    mcp_server = function(...) list(...)
+  )
+
+  launch_server(settings = server_file, host = "127.0.0.1", port = 1234L)
+
+  expect_equal(the$http_allowed_origins, "https://connect.example.com")
+})

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -99,7 +99,7 @@ test_that("HTTP requests validate Connect shared secret when configured", {
       REQUEST_METHOD = "GET",
       HTTP_PLUMBER_SHARED_SECRET = "secret"
     ))$status,
-    405L
+    200L
   )
 })
 
@@ -118,7 +118,7 @@ test_that("HTTP shared secret ignores empty override", {
       REQUEST_METHOD = "GET",
       HTTP_PLUMBER_SHARED_SECRET = "secret"
     ))$status,
-    405L
+    200L
   )
 })
 
@@ -140,7 +140,7 @@ test_that("HTTP shared secret uses non-empty mcptools override", {
       REQUEST_METHOD = "GET",
       HTTP_PLUMBER_SHARED_SECRET = "mcptools-secret"
     ))$status,
-    405L
+    200L
   )
 })
 
@@ -163,7 +163,7 @@ test_that("HTTP requests validate configured trusted hosts", {
       REQUEST_METHOD = "GET",
       HTTP_HOST = "127.0.0.1:1234"
     ))$status,
-    405L
+    200L
   )
 })
 
@@ -175,14 +175,14 @@ test_that("HTTP requests validate configured origins", {
       REQUEST_METHOD = "GET",
       HTTP_ORIGIN = "http://localhost:3000"
     ))$status,
-    405L
+    200L
   )
   expect_equal(
     handle_http_request(list(
       REQUEST_METHOD = "GET",
       HTTP_ORIGIN = "https://connect.example.com"
     ))$status,
-    405L
+    200L
   )
   expect_equal(
     handle_http_request(list(

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -80,6 +80,119 @@ test_that("check_not_interactive errors informatively", {
   expect_snapshot(error = TRUE, mcp_server())
 })
 
+test_that("HTTP requests validate Connect shared secret when configured", {
+  withr::local_options(plumber2.sharedSecret = "secret")
+
+  expect_equal(
+    handle_http_request(list(REQUEST_METHOD = "GET"))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_PLUMBER_SHARED_SECRET = "wrong"
+    ))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_PLUMBER_SHARED_SECRET = "secret"
+    ))$status,
+    405L
+  )
+})
+
+test_that("HTTP shared secret ignores empty override", {
+  withr::local_options(
+    mcptools.http_shared_secret = "",
+    plumber2.sharedSecret = "secret"
+  )
+
+  expect_equal(
+    handle_http_request(list(REQUEST_METHOD = "GET"))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_PLUMBER_SHARED_SECRET = "secret"
+    ))$status,
+    405L
+  )
+})
+
+test_that("HTTP shared secret uses non-empty mcptools override", {
+  withr::local_options(
+    mcptools.http_shared_secret = "mcptools-secret",
+    plumber2.sharedSecret = "connect-secret"
+  )
+
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_PLUMBER_SHARED_SECRET = "connect-secret"
+    ))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_PLUMBER_SHARED_SECRET = "mcptools-secret"
+    ))$status,
+    405L
+  )
+})
+
+test_that("HTTP requests validate configured trusted hosts", {
+  local_http_security(trusted_hosts = "127.0.0.1:1234")
+
+  expect_equal(
+    handle_http_request(list(REQUEST_METHOD = "GET"))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_HOST = "connect.example.com"
+    ))$status,
+    403L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_HOST = "127.0.0.1:1234"
+    ))$status,
+    405L
+  )
+})
+
+test_that("HTTP requests validate configured origins", {
+  local_http_security(allowed_origins = "https://connect.example.com")
+
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_ORIGIN = "http://localhost:3000"
+    ))$status,
+    405L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_ORIGIN = "https://connect.example.com"
+    ))$status,
+    405L
+  )
+  expect_equal(
+    handle_http_request(list(
+      REQUEST_METHOD = "GET",
+      HTTP_ORIGIN = "https://evil.example.com"
+    ))$status,
+    403L
+  )
+})
+
 test_that("forward_request returns append_tool_fn errors", {
   old_server_tools <- the$server_tools
   withr::defer(the$server_tools <- old_server_tools)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -63,6 +63,25 @@ test_that("to_json works", {
   expect_false(is.list(parsed$value))
 })
 
+test_that("url_origin handles full URLs and invalid input", {
+  expect_equal(
+    url_origin("https://connect.example.com/rsc/content/123"),
+    "https://connect.example.com"
+  )
+  expect_equal(
+    url_origin("https://connect.example.com:3939/rsc/content/123"),
+    "https://connect.example.com:3939"
+  )
+  expect_null(url_origin("not a url"))
+})
+
+test_that("constant_time_equal compares strings", {
+  expect_true(constant_time_equal("secret", "secret"))
+  expect_false(constant_time_equal("secret", "wrong"))
+  expect_false(constant_time_equal("secret", "secret2"))
+  expect_false(constant_time_equal("secret", NA_character_))
+})
+
 test_that("mcptools_server_log works", {
   # mcptools_server_log returns environment variable when set
   withr::local_envvar(MCPTOOLS_SERVER_LOG = "/custom/log/file.txt")

--- a/vignettes/server.Rmd
+++ b/vignettes/server.Rmd
@@ -45,6 +45,43 @@ In the case you have some client that you want to connect to R, **all you need t
 
 Then, you're good to go!
 
+## Posit Connect
+
+mcptools can also be deployed to Posit Connect as an HTTP MCP server. In the project directory, add a `_server.yml` file:
+
+```yaml
+engine: mcptools
+tools: tools.R
+```
+
+Then add `tools.R` with the tools to expose. The file should return a list of `ellmer::tool()` objects:
+
+```r
+list(
+  tool_rnorm = ellmer::tool(
+    fun = rnorm,
+    description = "Draw numbers from a random normal distribution.",
+    arguments = list(
+      n = ellmer::type_integer("The number of observations."),
+      mean = ellmer::type_number("The mean of the distribution."),
+      sd = ellmer::type_number("The standard deviation.")
+    )
+  )
+)
+```
+
+Deploy the directory as an R API and mark it as MCP content:
+
+```r
+rsconnect::deployAPI(".", contentCategory = "mcp")
+```
+
+If the content URL is `https://connect.example.com/content/abc123/`, use `https://connect.example.com/content/abc123/mcp` as the MCP endpoint. mcptools accepts requests at any path, so the content URL itself also works.
+
+If you cannot set `contentCategory = "mcp"` during deployment, set the MCP category in Connect after deploying and set minimum processes to at least 1.
+
+Connect deployments run tools inside the deployed R process by default. Session discovery is intended for local desktop R sessions and is disabled by default on Connect.
+
 ## Multiple clients and R sessions
 
 While a single client (and potentially a single R session) probably covers many users' use cases, mcptools supports multiple clients and multiple R sessions. For example, for the former, you may be both chatting in Claude Desktop and running Claude Code in a terminal somewhere. Or, in the multiple R sessions situation, you may have two or more Positron instances running at once, with different data science projects in each.


### PR DESCRIPTION
For the user, this looks like a `_server.yml` in the project directory. Under the hood, [Connect will look for a `launch_server()`](https://github.com/posit-dev/connect/blob/main/R/run_api.R#L176) in the namespace, which we just implement as an (internal) light wrapper around `mcp_server()`.