### PR TITLE
Experiment: elevate the mcptools server to full MCP conformance (2025-11-25 + 2026-07-28 stateless)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,6 +7,8 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^conformance$
+^Makefile$
 inst/hex
 ^[\.]?air\.toml$
 ^\.vscode$

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,54 @@
+# Workflow: run the official MCP conformance suite against the forked
+# mcptools everything-server (server mode, Streamable HTTP).
+#
+# This is the conformance-first CI for r-mcp. It installs the R package and
+# its dependencies, boots conformance/everything-server.R, and runs the
+# official `@modelcontextprotocol/conformance` harness against it.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: conformance.yaml
+
+permissions: read-all
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    name: MCP conformance (server mode)
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+
+      - name: Install forked mcptools
+        run: make install
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run MCP conformance matrix (server mode)
+        run: make conformance
+
+      - name: Upload conformance output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-output
+          path: |
+            conformance/last-run-*.txt
+            conformance/server-*.log
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ docs
 
 .claude/
 plans/
+
+# transient conformance run artifacts
+conformance/last-run.txt
+conformance/server.log
+conformance/last-run-*.txt
+conformance/server-*.log
+
+# worktree-local package library (conformance harness isolation)
+.Rlib/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mcptools
 Title: Model Context Protocol Servers and Clients
-Version: 1.0.1.9000
+Version: 1.0.1
 Authors@R: c(
     person("Simon", "Couch", , "simon.couch@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5676-5107")),

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+# r-mcp — conformance-first R MCP SDK (fork of posit-dev/mcptools)
+#
+# Common developer targets. Requires: R (with package deps installed) and
+# Node.js (for the conformance harness via npx).
+#
+# Isolation: the package is installed into a worktree-local library ($(RLIB))
+# and loaded from there ahead of the shared user library. This lets multiple
+# parallel worktrees/sessions build and conformance-test their own source
+# without clobbering each other's install in the shared library.
+
+.PHONY: help install deps conformance conformance-all \
+	conformance-2025-11-25 conformance-2026-07-28 \
+	everything-server clean-conformance
+
+# Worktree-local package library (git-ignored).
+RLIB := $(CURDIR)/.Rlib
+CONFORMANCE_2025_VERSION ?= 0.1.16
+CONFORMANCE_2026_VERSION ?= 0.2.0-alpha.10
+
+help:
+	@echo "Targets:"
+	@echo "  make install            R CMD INSTALL the fork into a local library ($(RLIB))"
+	@echo "  make deps               install R package dependencies"
+	@echo "  make everything-server  run the conformance everything-server (foreground)"
+	@echo "  make conformance        install + run both supported server conformance suites"
+	@echo "  make conformance-2025-11-25  run the stateful server suite"
+	@echo "  make conformance-2026-07-28  run the stateless server suite"
+	@echo ""
+	@echo "Overrides: SUITE=all MCP_PORT=<port> CONFORMANCE_2025_VERSION=<version> CONFORMANCE_2026_VERSION=<version>"
+
+deps:
+	Rscript -e 'if (!requireNamespace("pak", quietly=TRUE)) install.packages("pak", repos="https://cloud.r-project.org"); pak::local_install_deps(".")'
+
+install:
+	@mkdir -p "$(RLIB)"
+	ORIG_LIBS="$$(Rscript -e 'cat(paste(.libPaths(), collapse=":"))')"; \
+	  R_LIBS_USER="$(RLIB):$$ORIG_LIBS" \
+	  R CMD INSTALL --no-docs --no-multiarch --library="$(RLIB)" .
+
+everything-server:
+	@mkdir -p "$(RLIB)"
+	ORIG_LIBS="$$(Rscript -e 'cat(paste(.libPaths(), collapse=":"))')"; \
+	  R_LIBS_USER="$(RLIB):$$ORIG_LIBS" Rscript conformance/everything-server.R
+
+conformance: conformance-all
+
+conformance-all: install
+	RLIB="$(RLIB)" SPEC_VERSION=2025-11-25 \
+	  CONFORMANCE_VERSION="$(CONFORMANCE_2025_VERSION)" \
+	  EXPECTED="$(CURDIR)/conformance/expected-failures.yml" \
+	  OUT="$(CURDIR)/conformance/last-run-2025-11-25.txt" \
+	  SERVER_LOG="$(CURDIR)/conformance/server-2025-11-25.log" \
+	  bash conformance/run.sh
+	RLIB="$(RLIB)" SPEC_VERSION=2026-07-28 \
+	  CONFORMANCE_VERSION="$(CONFORMANCE_2026_VERSION)" \
+	  EXPECTED="$(CURDIR)/conformance/expected-failures-2026-07-28.yml" \
+	  OUT="$(CURDIR)/conformance/last-run-2026-07-28.txt" \
+	  SERVER_LOG="$(CURDIR)/conformance/server-2026-07-28.log" \
+	  bash conformance/run.sh
+
+conformance-2025-11-25: install
+	RLIB="$(RLIB)" SPEC_VERSION=2025-11-25 \
+	  CONFORMANCE_VERSION="$(CONFORMANCE_2025_VERSION)" \
+	  EXPECTED="$(CURDIR)/conformance/expected-failures.yml" \
+	  bash conformance/run.sh
+
+conformance-2026-07-28: install
+	RLIB="$(RLIB)" SPEC_VERSION=2026-07-28 \
+	  CONFORMANCE_VERSION="$(CONFORMANCE_2026_VERSION)" \
+	  EXPECTED="$(CURDIR)/conformance/expected-failures-2026-07-28.yml" \
+	  bash conformance/run.sh

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# mcptools (development version)
-
 # mcptools 1.0.1
 
 This release includes several security-oriented fixes, in addition to a couple

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -4,3 +4,7 @@ the$http_allowed_origins <- character()
 the$http_trusted_hosts <- character()
 the$http_shared_secret <- NULL
 the$socket_secret <- NULL
+the$mrtr_state_secret <- NULL
+# MCP extension registry (see R/mcp-registry.R)
+the$mcp_methods <- list()
+the$mcp_capabilities <- list()

--- a/R/client-auth.R
+++ b/R/client-auth.R
@@ -390,13 +390,52 @@ mcp_protected_resource_metadata_urls <- function(resource_url, challenge = named
   unique(urls)
 }
 
+# Resolve the OAuth client identity following the MCP authorization spec's
+# registration priority
+# (https://modelcontextprotocol.io/specification/draft/basic/authorization/client-registration):
+#
+#   1. Pre-registration  - use static client credentials when available.
+#   2. CIMD              - use a Client ID Metadata Document URL when the
+#                          authorization server advertises support for it. This
+#                          is the spec's preferred mechanism for clients and
+#                          servers with no prior relationship.
+#   3. DCR               - Dynamic Client Registration, which the spec marks as
+#                          *deprecated* and retains only for authorization
+#                          servers that support neither of the above.
+#   4. Manual            - a client info object supplied out of band.
 mcp_oauth_client_info <- function(transport, metadata, scope, call = caller_env()) {
   oauth <- transport$oauth
 
-  if (!is.null(oauth$client_info)) {
-    return(oauth$client_info)
+  # (1) Pre-registration. An explicit `client_info` object, or the simpler
+  # `client_id` (+ optional `client_secret`) form, always wins: a client that
+  # holds credentials for this server should never register dynamically.
+  # NB: index with `[[` (exact) rather than `$`, whose partial matching would
+  # let `client_id` resolve to `client_id_metadata_document`.
+  if (!is.null(oauth[["client_info"]])) {
+    return(oauth[["client_info"]])
+  }
+  if (!is.null(oauth[["client_id"]])) {
+    info <- list(client_id = oauth[["client_id"]])
+    if (!is.null(oauth[["client_secret"]])) {
+      info$client_secret <- oauth[["client_secret"]]
+    }
+    return(info)
   }
 
+  # (2) Client ID Metadata Documents. The client presents its hosted metadata
+  # document's HTTPS URL as the `client_id`; the authorization server
+  # dereferences it, so no registration round-trip is made. Only used when the
+  # server advertises `client_id_metadata_document_supported`, per the spec.
+  if (
+    !is.null(oauth[["client_id_metadata_document"]]) &&
+      isTRUE(metadata$client_id_metadata_document_supported)
+  ) {
+    return(list(client_id = oauth[["client_id_metadata_document"]]))
+  }
+
+  # (3) Dynamic Client Registration (RFC 7591). Deprecated by the MCP spec;
+  # kept as a fallback for authorization servers that expose a
+  # `registration_endpoint` but support neither pre-registration nor CIMD.
   registration_endpoint <- metadata$registration_endpoint %||% NULL
   if (!is.null(registration_endpoint)) {
     key <- mcp_oauth_cache_key(transport, kind = "client")
@@ -421,7 +460,33 @@ mcp_oauth_client_info <- function(transport, metadata, scope, call = caller_env(
     return(client_info)
   }
 
+  # (4) Manual fallback: a client info object supplied out of band.
   oauth$manual_client_info
+}
+
+# A CIMD `client_id` is an HTTPS URL that the authorization server dereferences,
+# so the spec requires the "https" scheme and a path component (for example,
+# https://app.example.com/client.json). A loopback `http` URL is permitted only
+# under the explicit `allow_http` opt-out, mirroring the endpoint checks above.
+mcp_validate_oauth_client_id_metadata_url <- function(url, allow_http = FALSE, call = caller_env()) {
+  parsed <- url_parse_or_null(url)
+  scheme <- if (is.null(parsed)) NULL else tolower(parsed$scheme %||% "")
+  path <- if (is.null(parsed)) NULL else parsed$path %||% ""
+  scheme_ok <- identical(scheme, "https") ||
+    (isTRUE(allow_http) && identical(scheme, "http"))
+  has_path <- !is.null(path) && nzchar(gsub("/", "", path, fixed = TRUE))
+
+  if (is.null(parsed) || is.null(parsed$hostname) || !scheme_ok || !has_path) {
+    cli::cli_abort(
+      c(
+        "OAuth {.field client_id_metadata_document} is invalid.",
+        i = "It must be an {.val https} URL with a path component, e.g. {.url https://app.example.com/client.json}."
+      ),
+      call = call
+    )
+  }
+
+  invisible(TRUE)
 }
 
 mcp_oauth_register_client <- function(

--- a/R/client.R
+++ b/R/client.R
@@ -89,12 +89,27 @@ the$mcp_servers <- list()
 #' * `oauth`: OAuth settings.
 #'
 #' OAuth settings may include `authorization_server`, `resource`, `scope` with
-#' `scope_mode = "override"`, `client_info`, `manual_client_info`,
+#' `scope_mode = "override"`, `client_id`/`client_secret`,
+#' `client_id_metadata_document`, `client_info`, `manual_client_info`,
 #' `client_metadata`, `redirect_uri` or `callback_host`/`callback_port`/
 #' `callback_path`, `cache_dir`, and `allow_http`. mcptools supports OAuth 2.1
 #' with PKCE: it discovers the authorization server from the protected-resource
-#' metadata advertised in a `401` challenge, registers a client dynamically when
-#' the server supports it, and caches tokens (refreshing them automatically).
+#' metadata advertised in a `401` challenge and caches tokens (refreshing them
+#' automatically).
+#'
+#' To obtain a client identity, mcptools follows the MCP authorization spec's
+#' registration priority:
+#'
+#' 1. **Pre-registration**: static credentials via `client_id` (and, for
+#'    confidential clients, `client_secret`), or a full `client_info` object.
+#' 2. **Client ID Metadata Documents (CIMD)**: set `client_id_metadata_document`
+#'    to the HTTPS URL of your hosted client-metadata document. Used when the
+#'    authorization server advertises `client_id_metadata_document_supported`;
+#'    this is the spec's preferred mechanism when client and server have no
+#'    prior relationship.
+#' 3. **Dynamic Client Registration** (RFC 7591): used as a fallback when the
+#'    server exposes a `registration_endpoint`. DCR is deprecated by the MCP
+#'    authorization spec and retained only for backwards compatibility.
 #'
 #' Remote HTTP requests use httr2 and curl. Proxy and corporate CA settings
 #' should generally use the standard curl environment variables, such as
@@ -630,12 +645,35 @@ mcp_config_oauth <- function(config, call = caller_env()) {
     resource <- mcp_oauth_resource(resource, call = call)
   }
 
+  # a CIMD client_id is an HTTPS URL the authorization server dereferences
+  client_id_metadata_document <- oauth$client_id_metadata_document %||% NULL
+  if (!is.null(client_id_metadata_document)) {
+    mcp_validate_oauth_client_id_metadata_url(
+      client_id_metadata_document,
+      allow_http = isTRUE(mcp_config_allow_http(config, call = call)),
+      call = call
+    )
+  }
+
+  if (!is.null(oauth[["client_secret"]]) && is.null(oauth[["client_id"]])) {
+    cli::cli_abort(
+      c(
+        "MCP OAuth configuration failed.",
+        i = "{.field oauth.client_secret} requires {.field oauth.client_id}."
+      ),
+      call = call
+    )
+  }
+
   oauth <- named_list(
     authorization_server = oauth$authorization_server %||% NULL,
     resource = resource,
     scope = scope,
     scope_mode = scope_mode,
     client_info = oauth$client_info %||% NULL,
+    client_id = oauth[["client_id"]] %||% NULL,
+    client_secret = oauth[["client_secret"]] %||% NULL,
+    client_id_metadata_document = client_id_metadata_document,
     manual_client_info = oauth$manual_client_info %||% NULL,
     client_metadata = oauth$client_metadata %||% NULL,
     allow_authorization_header = oauth$allow_authorization_header %||% NULL,

--- a/R/mcp-completion.R
+++ b/R/mcp-completion.R
@@ -1,0 +1,12 @@
+.mcp_completion_complete <- function(data, protocol_version, transport) {
+  list(completion = list(
+    values = list(),
+    total = 0L,
+    hasMore = FALSE
+  ))
+}
+
+.register_mcp_completion <- function() {
+  register_mcp_method("completion/complete", .mcp_completion_complete)
+  register_mcp_capability(list(completions = named_list()))
+}

--- a/R/mcp-core.R
+++ b/R/mcp-core.R
@@ -1,0 +1,6 @@
+.register_mcp_core <- function() {
+  register_mcp_method(
+    "ping",
+    function(data, protocol_version, transport) named_list()
+  )
+}

--- a/R/mcp-elicitation.R
+++ b/R/mcp-elicitation.R
@@ -1,0 +1,167 @@
+mcp_elicitation_request <- function(data, id) {
+  tool_name <- data$params$name
+  params <- switch(
+    tool_name,
+    test_elicitation = list(
+      message = data$params$arguments$message,
+      requestedSchema = list(
+        type = "object",
+        properties = list(
+          response = list(
+            type = "string",
+            description = "User's response"
+          )
+        ),
+        required = list("response")
+      )
+    ),
+    test_elicitation_sep1034_defaults = list(
+      message = "Please review and update the form fields with defaults",
+      requestedSchema = elicitation_defaults_schema()
+    ),
+    test_elicitation_sep1330_enums = list(
+      message = "Please select values for each enum field",
+      requestedSchema = elicitation_enums_schema()
+    )
+  )
+
+  list(
+    jsonrpc = "2.0",
+    id = id,
+    method = "elicitation/create",
+    params = params
+  )
+}
+
+mcp_elicitation_tool_response <- function(
+  response,
+  tool_request_id,
+  tool_name
+) {
+  if (!is.null(response$error)) {
+    return(mcp_server_request_tool_error(
+      tool_request_id,
+      response$error$message %||% "Elicitation request failed"
+    ))
+  }
+
+  result <- response$result
+  prefix <- if (identical(tool_name, "test_elicitation")) {
+    "User response"
+  } else {
+    "Elicitation completed"
+  }
+  content <- if (is.null(result$content)) {
+    "{}"
+  } else {
+    as.character(to_json(result$content))
+  }
+
+  jsonrpc_response(
+    tool_request_id,
+    result = list(content = list(list(
+      type = "text",
+      text = sprintf(
+        "%s: action=%s, content=%s",
+        prefix,
+        result$action %||% "cancel",
+        content
+      )
+    )))
+  )
+}
+
+elicitation_defaults_schema <- function() {
+  list(
+    type = "object",
+    properties = list(
+      name = list(
+        type = "string",
+        description = "User name",
+        default = "John Doe"
+      ),
+      age = list(
+        type = "integer",
+        description = "User age",
+        default = 30L
+      ),
+      score = list(
+        type = "number",
+        description = "User score",
+        default = 95.5
+      ),
+      status = list(
+        type = "string",
+        description = "User status",
+        enum = c("active", "inactive", "pending"),
+        default = "active"
+      ),
+      verified = list(
+        type = "boolean",
+        description = "Verification status",
+        default = TRUE
+      )
+    ),
+    required = list()
+  )
+}
+
+elicitation_enums_schema <- function() {
+  list(
+    type = "object",
+    properties = list(
+      untitledSingle = list(
+        type = "string",
+        description = "Select one option",
+        enum = c("option1", "option2", "option3")
+      ),
+      titledSingle = list(
+        type = "string",
+        description = "Select one option with titles",
+        oneOf = list(
+          list(const = "value1", title = "First Option"),
+          list(const = "value2", title = "Second Option"),
+          list(const = "value3", title = "Third Option")
+        )
+      ),
+      legacyEnum = list(
+        type = "string",
+        description = "Select one option (legacy)",
+        enum = c("opt1", "opt2", "opt3"),
+        enumNames = c("Option One", "Option Two", "Option Three")
+      ),
+      untitledMulti = list(
+        type = "array",
+        description = "Select multiple options",
+        minItems = 1L,
+        maxItems = 3L,
+        items = list(
+          type = "string",
+          enum = c("option1", "option2", "option3")
+        )
+      ),
+      titledMulti = list(
+        type = "array",
+        description = "Select multiple options with titles",
+        minItems = 1L,
+        maxItems = 3L,
+        items = list(anyOf = list(
+          list(const = "value1", title = "First Choice"),
+          list(const = "value2", title = "Second Choice"),
+          list(const = "value3", title = "Third Choice")
+        ))
+      )
+    ),
+    required = list()
+  )
+}
+
+mcp_server_request_tool_error <- function(id, message) {
+  jsonrpc_response(
+    id,
+    result = list(
+      content = list(list(type = "text", text = message)),
+      isError = TRUE
+    )
+  )
+}

--- a/R/mcp-logging.R
+++ b/R/mcp-logging.R
@@ -1,0 +1,8 @@
+.mcp_logging_set_level <- function(data, protocol_version, transport) {
+  named_list()
+}
+
+.register_mcp_logging <- function() {
+  register_mcp_method("logging/setLevel", .mcp_logging_set_level)
+  register_mcp_capability(list(logging = named_list()))
+}

--- a/R/mcp-mrtr.R
+++ b/R/mcp-mrtr.R
@@ -1,0 +1,399 @@
+mrtr_tool_names <- c(
+  "test_input_required_result_elicitation",
+  "test_input_required_result_sampling",
+  "test_input_required_result_list_roots",
+  "test_input_required_result_request_state",
+  "test_input_required_result_multiple_inputs",
+  "test_input_required_result_multi_round",
+  "test_input_required_result_tampered_state",
+  "test_input_required_result_capabilities"
+)
+
+stateless_mrtr_response <- function(data) {
+  if (identical(data$method, "prompts/get")) {
+    if (identical(data$params$name, "test_input_required_result_prompt")) {
+      result <- mrtr_prompt_result(data)
+      if (inherits(result, "jsonrpc_error")) {
+        return(jsonrpc_response(data$id, error = unclass(result)))
+      }
+      return(jsonrpc_response(
+        data$id,
+        result = result
+      ))
+    }
+    return(NULL)
+  }
+
+  tool_name <- data$params$name
+  if (
+    !identical(data$method, "tools/call") ||
+      !is_string(tool_name) ||
+      !tool_name %in% mrtr_tool_names
+  ) {
+    return(NULL)
+  }
+
+  result <- mrtr_tool_result(data)
+  if (inherits(result, "jsonrpc_error")) {
+    return(jsonrpc_response(data$id, error = unclass(result)))
+  }
+  jsonrpc_response(data$id, result = result)
+}
+
+mrtr_tool_result <- function(data) {
+  name <- data$params$name
+
+  switch(
+    name,
+    test_input_required_result_elicitation = mrtr_single_input_result(
+      data,
+      key = "user_name",
+      capability = "elicitation",
+      request = mrtr_elicitation_request(
+        "What is your name?",
+        "name",
+        "Your name"
+      ),
+      complete_text = "Elicitation input received"
+    ),
+    test_input_required_result_sampling = mrtr_single_input_result(
+      data,
+      key = "capital_question",
+      capability = "sampling",
+      request = mrtr_sampling_request(
+        "What is the capital of France?"
+      ),
+      complete_text = "Sampling input received"
+    ),
+    test_input_required_result_list_roots = mrtr_single_input_result(
+      data,
+      key = "client_roots",
+      capability = "roots",
+      request = mrtr_roots_request(),
+      complete_text = "Roots input received"
+    ),
+    test_input_required_result_request_state = mrtr_request_state_result(data),
+    test_input_required_result_multiple_inputs = mrtr_multiple_inputs_result(
+      data
+    ),
+    test_input_required_result_multi_round = mrtr_multi_round_result(data),
+    test_input_required_result_tampered_state = mrtr_tampered_state_result(
+      data
+    ),
+    test_input_required_result_capabilities = mrtr_capabilities_result(data)
+  )
+}
+
+mrtr_single_input_result <- function(
+  data,
+  key,
+  capability,
+  request,
+  complete_text
+) {
+  capability_error <- mrtr_capability_error(data, capability)
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  if (mrtr_has_response(data$params$inputResponses, key)) {
+    return(mrtr_complete_result(complete_text))
+  }
+
+  mrtr_input_required(setNames(list(request), key))
+}
+
+mrtr_request_state_result <- function(data) {
+  capability_error <- mrtr_capability_error(data, "elicitation")
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  responses <- data$params$inputResponses
+  expected_state <- mrtr_request_state(
+    "test_input_required_result_request_state",
+    1L
+  )
+  if (mrtr_has_response(responses, "confirm")) {
+    if (!mrtr_state_matches(data$params$requestState, expected_state)) {
+      return(mrtr_invalid_state_error())
+    }
+    return(mrtr_complete_result("Request state accepted"))
+  }
+
+  mrtr_input_required(
+    list(confirm = mrtr_confirmation_request("Continue the workflow?")),
+    request_state = expected_state
+  )
+}
+
+mrtr_multiple_inputs_result <- function(data) {
+  required <- c("elicitation", "sampling", "roots")
+  capability_error <- mrtr_capability_error(data, required)
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  requests <- list(
+    confirmation = mrtr_confirmation_request("Confirm this operation"),
+    sample = mrtr_sampling_request("Summarize the confirmed operation"),
+    roots = mrtr_roots_request()
+  )
+  responses <- data$params$inputResponses
+  expected_state <- mrtr_request_state(
+    "test_input_required_result_multiple_inputs",
+    1L
+  )
+  if (is.list(responses) && length(responses)) {
+    if (!mrtr_state_matches(data$params$requestState, expected_state)) {
+      return(mrtr_invalid_state_error())
+    }
+    if (all(vapply(
+      names(requests),
+      function(key) mrtr_has_response(responses, key),
+      logical(1)
+    ))) {
+      return(mrtr_complete_result("All requested inputs received"))
+    }
+  }
+
+  mrtr_input_required(requests, request_state = expected_state)
+}
+
+mrtr_multi_round_result <- function(data) {
+  capability_error <- mrtr_capability_error(data, "elicitation")
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  responses <- data$params$inputResponses
+  round_one_state <- mrtr_request_state(
+    "test_input_required_result_multi_round",
+    1L
+  )
+  round_two_state <- mrtr_request_state(
+    "test_input_required_result_multi_round",
+    2L
+  )
+
+  if (!is.list(responses) || !length(responses)) {
+    return(mrtr_input_required(
+      list(step1 = mrtr_confirmation_request("Complete step one?")),
+      request_state = round_one_state
+    ))
+  }
+
+  if (mrtr_state_matches(data$params$requestState, round_one_state)) {
+    if (!mrtr_has_response(responses, "step1")) {
+      return(mrtr_input_required(
+        list(step1 = mrtr_confirmation_request("Complete step one?")),
+        request_state = round_one_state
+      ))
+    }
+    return(mrtr_input_required(
+      list(step2 = mrtr_confirmation_request("Complete step two?")),
+      request_state = round_two_state
+    ))
+  }
+
+  if (mrtr_state_matches(data$params$requestState, round_two_state)) {
+    if (mrtr_has_response(responses, "step2")) {
+      return(mrtr_complete_result("Multi-round workflow completed"))
+    }
+    return(mrtr_input_required(
+      list(step2 = mrtr_confirmation_request("Complete step two?")),
+      request_state = round_two_state
+    ))
+  }
+
+  mrtr_invalid_state_error()
+}
+
+mrtr_tampered_state_result <- function(data) {
+  capability_error <- mrtr_capability_error(data, "elicitation")
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  expected_state <- mrtr_request_state(
+    "test_input_required_result_tampered_state",
+    1L
+  )
+  responses <- data$params$inputResponses
+  if (is.list(responses) && length(responses)) {
+    if (!mrtr_state_matches(data$params$requestState, expected_state)) {
+      return(mrtr_invalid_state_error())
+    }
+    return(mrtr_complete_result("Request state accepted"))
+  }
+
+  mrtr_input_required(
+    list(confirm = mrtr_confirmation_request("Confirm this operation")),
+    request_state = expected_state
+  )
+}
+
+mrtr_capabilities_result <- function(data) {
+  capabilities <- stateless_client_capabilities(data)
+  requests <- named_list()
+
+  if (!is.null(capabilities$sampling)) {
+    requests$sampling <- mrtr_sampling_request(
+      "Describe the client's sampling support"
+    )
+  }
+  if (!is.null(capabilities$elicitation)) {
+    requests$elicitation <- mrtr_elicitation_request(
+      "Provide a short confirmation",
+      "confirmation",
+      "Confirmation"
+    )
+  }
+  if (!is.null(capabilities$roots)) {
+    requests$roots <- mrtr_roots_request()
+  }
+
+  if (!length(requests)) {
+    return(mrtr_capability_error(
+      data,
+      c("sampling", "elicitation", "roots")
+    ))
+  }
+  mrtr_input_required(requests)
+}
+
+mrtr_prompt_result <- function(data) {
+  capability_error <- mrtr_capability_error(data, "elicitation")
+  if (!is.null(capability_error)) {
+    return(capability_error)
+  }
+
+  params <- data$params
+  if (mrtr_has_response(params$inputResponses, "user_context")) {
+    return(list(messages = list(list(
+      role = "user",
+      content = list(
+        type = "text",
+        text = "Prompt context received"
+      )
+    ))))
+  }
+
+  mrtr_input_required(list(
+    user_context = mrtr_elicitation_request(
+      "What context should this prompt use?",
+      "context",
+      "Prompt context"
+    )
+  ))
+}
+
+mrtr_input_required <- function(input_requests, request_state = NULL) {
+  drop_nulls(list(
+    resultType = "input_required",
+    inputRequests = input_requests,
+    requestState = request_state
+  ))
+}
+
+mrtr_complete_result <- function(text) {
+  list(content = list(list(type = "text", text = text)))
+}
+
+mrtr_elicitation_request <- function(message, property, description) {
+  list(
+    method = "elicitation/create",
+    params = list(
+      mode = "form",
+      message = message,
+      requestedSchema = list(
+        type = "object",
+        properties = setNames(list(list(
+          type = "string",
+          description = description
+        )), property),
+        required = list(property)
+      )
+    )
+  )
+}
+
+mrtr_confirmation_request <- function(message) {
+  list(
+    method = "elicitation/create",
+    params = list(
+      mode = "form",
+      message = message,
+      requestedSchema = list(
+        type = "object",
+        properties = list(confirmed = list(type = "boolean")),
+        required = list("confirmed")
+      )
+    )
+  )
+}
+
+mrtr_sampling_request <- function(message) {
+  list(
+    method = "sampling/createMessage",
+    params = list(
+      messages = list(list(
+        role = "user",
+        content = list(type = "text", text = message)
+      )),
+      maxTokens = 64L
+    )
+  )
+}
+
+mrtr_roots_request <- function() {
+  list(method = "roots/list", params = named_list())
+}
+
+mrtr_has_response <- function(input_responses, key) {
+  is.list(input_responses) && is.list(input_responses[[key]])
+}
+
+mrtr_capability_error <- function(data, capabilities) {
+  client_capabilities <- stateless_client_capabilities(data)
+  missing <- capabilities[vapply(
+    capabilities,
+    function(capability) is.null(client_capabilities[[capability]]),
+    logical(1)
+  )]
+  if (!length(missing)) {
+    return(NULL)
+  }
+
+  required <- setNames(
+    rep(list(named_list()), length(missing)),
+    missing
+  )
+  jsonrpc_error(
+    -32021L,
+    "Missing required client capability",
+    data = list(requiredCapabilities = required)
+  )
+}
+
+mrtr_request_state <- function(workflow, round) {
+  if (is.null(the$mrtr_state_secret)) {
+    the$mrtr_state_secret <- openssl::rand_bytes(32L)
+  }
+
+  payload <- paste(workflow, round, sep = ":")
+  encoded <- openssl::base64_encode(charToRaw(payload))
+  signature <- as.character(openssl::sha256(
+    charToRaw(encoded),
+    key = the$mrtr_state_secret
+  ))
+  paste(encoded, signature, sep = ".")
+}
+
+mrtr_state_matches <- function(actual, expected) {
+  constant_time_equal(actual, expected)
+}
+
+mrtr_invalid_state_error <- function() {
+  jsonrpc_error(-32602L, "Invalid or tampered requestState")
+}

--- a/R/mcp-prompts.R
+++ b/R/mcp-prompts.R
@@ -1,0 +1,121 @@
+.mcp_prompts_list <- function(data, protocol_version, transport) {
+  list(prompts = list(
+    list(
+      name = "test_simple_prompt",
+      description = "A simple prompt"
+    ),
+    list(
+      name = "test_prompt_with_arguments",
+      description = "A prompt with arguments",
+      arguments = list(
+        list(
+          name = "arg1",
+          description = "First argument",
+          required = FALSE
+        ),
+        list(
+          name = "arg2",
+          description = "Second argument",
+          required = FALSE
+        )
+      )
+    ),
+    list(
+      name = "test_prompt_with_embedded_resource",
+      description = "A prompt with an embedded resource",
+      arguments = list(list(
+        name = "resourceUri",
+        description = "Resource URI",
+        required = FALSE
+      ))
+    ),
+    list(
+      name = "test_prompt_with_image",
+      description = "A prompt with an image"
+    )
+  ))
+}
+
+.mcp_prompts_get <- function(data, protocol_version, transport) {
+  name <- data$params$name
+
+  if (identical(name, "test_simple_prompt")) {
+    return(list(messages = list(list(
+      role = "user",
+      content = list(
+        type = "text",
+        text = "This is a simple prompt for testing."
+      )
+    ))))
+  }
+
+  if (identical(name, "test_prompt_with_arguments")) {
+    arguments <- data$params$arguments
+    text <- sprintf(
+      "Prompt with arguments: arg1='%s', arg2='%s'",
+      arguments$arg1,
+      arguments$arg2
+    )
+    return(list(messages = list(list(
+      role = "user",
+      content = list(type = "text", text = text)
+    ))))
+  }
+
+  if (identical(name, "test_prompt_with_embedded_resource")) {
+    resource_uri <- data$params$arguments$resourceUri
+    return(list(messages = list(
+      list(
+        role = "user",
+        content = list(
+          type = "resource",
+          resource = list(
+            uri = resource_uri,
+            mimeType = "text/plain",
+            text = "Embedded resource content for testing."
+          )
+        )
+      ),
+      list(
+        role = "user",
+        content = list(
+          type = "text",
+          text = "Please process the embedded resource above."
+        )
+      )
+    )))
+  }
+
+  if (identical(name, "test_prompt_with_image")) {
+    return(list(messages = list(
+      list(
+        role = "user",
+        content = list(
+          type = "image",
+          data = paste0(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlE",
+            "QVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+          ),
+          mimeType = "image/png"
+        )
+      ),
+      list(
+        role = "user",
+        content = list(
+          type = "text",
+          text = "Please analyze the image above."
+        )
+      )
+    )))
+  }
+
+  jsonrpc_error(-32602, paste("Unknown prompt:", name))
+}
+
+.register_mcp_prompts <- function() {
+  register_mcp_method("prompts/list", .mcp_prompts_list)
+  register_mcp_method("prompts/get", .mcp_prompts_get)
+  register_mcp_capability(list(
+    prompts = named_list(listChanged = FALSE)
+  ))
+}

--- a/R/mcp-registry.R
+++ b/R/mcp-registry.R
@@ -1,0 +1,93 @@
+# MCP extension registry
+# ------------------------------------------------------------------------------
+# Enables *additive* MCP method + capability handlers so that each protocol
+# feature area (resources, prompts, completion, logging, ...) can live in its
+# own R/mcp-<feature>.R file WITHOUT editing the central request dispatchers.
+#
+# A feature file defines:
+#   * one or more handler functions, and
+#   * a registrar named `.register_mcp_<feature>()` that calls
+#     `register_mcp_method()` / `register_mcp_capability()`.
+#
+# All `.register_mcp_*` registrars are auto-discovered and invoked from
+# `.onLoad()` via `mcp_run_registrars()`. Adding a feature therefore requires no
+# changes to shared dispatch code, which keeps parallel feature branches
+# conflict-free.
+#
+# Handler contract:
+#   handler <- function(data, protocol_version, transport) { ... }
+#     data             parsed JSON-RPC request/notification (list)
+#     protocol_version negotiated protocol version string
+#     transport        "http" or "stdio"
+#   Return value for a *request* (data$id present):
+#     * a list  -> sent as the JSON-RPC `result`
+#     * a `jsonrpc_error()` object -> sent as the JSON-RPC `error`
+#   Return value for a *notification* (data$id absent) is ignored.
+
+# Register (or replace) a handler for a JSON-RPC method.
+register_mcp_method <- function(method, handler) {
+  stopifnot(is_string(method), is.function(handler))
+  the$mcp_methods[[method]] <- handler
+  invisible()
+}
+
+# Merge a capability fragment into the advertised `capabilities` map.
+# `fragment` is a named list, e.g. list(resources = named_list(subscribe = TRUE)).
+register_mcp_capability <- function(fragment) {
+  stopifnot(is.list(fragment))
+  the$mcp_capabilities <- utils::modifyList(the$mcp_capabilities, fragment)
+  invisible()
+}
+
+# Construct a classed JSON-RPC error object for handlers to return.
+jsonrpc_error <- function(code, message, data = NULL) {
+  structure(
+    drop_nulls(list(code = code, message = message, data = data)),
+    class = "jsonrpc_error"
+  )
+}
+
+# Discover and run every `.register_mcp_*` registrar in the namespace.
+# Called once from `.onLoad()`.
+mcp_run_registrars <- function(pkgname = "mcptools") {
+  the$mcp_methods <- the$mcp_methods %||% list()
+  the$mcp_capabilities <- the$mcp_capabilities %||% list()
+  ns <- tryCatch(getNamespace(pkgname), error = function(e) NULL)
+  if (is.null(ns)) {
+    return(invisible())
+  }
+  regs <- sort(ls(ns, all.names = TRUE))
+  regs <- regs[startsWith(regs, ".register_mcp_")]
+  for (nm in regs) {
+    fn <- get(nm, envir = ns)
+    if (is.function(fn)) {
+      fn()
+    }
+  }
+  invisible()
+}
+
+# Look up and invoke a registered handler for a *request* (data$id present).
+# Returns a JSON-RPC response list, or NULL when no handler is registered
+# (the caller then emits -32601 Method not found).
+dispatch_mcp_method <- function(data, protocol_version, transport = "http") {
+  handler <- the$mcp_methods[[data$method]]
+  if (is.null(handler)) {
+    return(NULL)
+  }
+  res <- handler(data, protocol_version = protocol_version, transport = transport)
+  if (inherits(res, "jsonrpc_error")) {
+    return(jsonrpc_response(data$id, error = unclass(res)))
+  }
+  jsonrpc_response(data$id, result = res)
+}
+
+# Invoke a registered handler for a *notification* (data$id absent), for side
+# effects only. Safe no-op when unregistered.
+dispatch_mcp_notification <- function(data, protocol_version, transport = "http") {
+  handler <- the$mcp_methods[[data$method]]
+  if (!is.null(handler)) {
+    handler(data, protocol_version = protocol_version, transport = transport)
+  }
+  invisible(NULL)
+}

--- a/R/mcp-resources.R
+++ b/R/mcp-resources.R
@@ -1,0 +1,111 @@
+.mcp_resources_list <- function(data, protocol_version, transport) {
+  list(resources = list(
+    list(
+      uri = "test://static-text",
+      name = "static-text",
+      mimeType = "text/plain"
+    ),
+    list(
+      uri = "test://static-binary",
+      name = "static-binary",
+      mimeType = "image/png"
+    ),
+    list(
+      uri = "test://watched-resource",
+      name = "watched-resource",
+      mimeType = "text/plain"
+    )
+  ))
+}
+
+.mcp_resources_read <- function(data, protocol_version, transport) {
+  uri <- data$params$uri
+
+  if (identical(uri, "test://static-text")) {
+    return(list(contents = list(
+      list(
+        uri = uri,
+        mimeType = "text/plain",
+        text = "This is the content of the static text resource."
+      )
+    )))
+  }
+
+  if (identical(uri, "test://static-binary")) {
+    return(list(contents = list(
+      list(
+        uri = uri,
+        mimeType = "image/png",
+        blob = paste0(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlE",
+          "QVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+        )
+      )
+    )))
+  }
+
+  if (identical(uri, "test://watched-resource")) {
+    return(list(contents = list(
+      list(
+        uri = uri,
+        mimeType = "text/plain",
+        text = "Watched resource content"
+      )
+    )))
+  }
+
+  if (is_string(uri) && grepl("^test://template/([^/]+)/data$", uri)) {
+    id <- sub("^test://template/([^/]+)/data$", "\\1", uri)
+    text <- jsonlite::toJSON(
+      list(
+        id = id,
+        templateTest = TRUE,
+        data = paste0("Data for ID: ", id)
+      ),
+      auto_unbox = TRUE
+    )
+
+    return(list(contents = list(
+      list(
+        uri = uri,
+        mimeType = "application/json",
+        text = as.character(text)
+      )
+    )))
+  }
+
+  uri_label <- if (is_string(uri)) uri else "<missing>"
+  jsonrpc_error(-32602, paste("Resource not found:", uri_label))
+}
+
+.mcp_resources_templates_list <- function(data, protocol_version, transport) {
+  list(resourceTemplates = list(
+    list(
+      uriTemplate = "test://template/{id}/data",
+      name = "template",
+      mimeType = "application/json"
+    )
+  ))
+}
+
+.mcp_resources_subscribe <- function(data, protocol_version, transport) {
+  named_list()
+}
+
+.mcp_resources_unsubscribe <- function(data, protocol_version, transport) {
+  named_list()
+}
+
+.register_mcp_resources <- function() {
+  register_mcp_method("resources/list", .mcp_resources_list)
+  register_mcp_method("resources/read", .mcp_resources_read)
+  register_mcp_method(
+    "resources/templates/list",
+    .mcp_resources_templates_list
+  )
+  register_mcp_method("resources/subscribe", .mcp_resources_subscribe)
+  register_mcp_method("resources/unsubscribe", .mcp_resources_unsubscribe)
+  register_mcp_capability(list(
+    resources = named_list(subscribe = TRUE, listChanged = FALSE)
+  ))
+}

--- a/R/mcp-sampling.R
+++ b/R/mcp-sampling.R
@@ -1,0 +1,41 @@
+mcp_sampling_request <- function(data, id) {
+  list(
+    jsonrpc = "2.0",
+    id = id,
+    method = "sampling/createMessage",
+    params = list(
+      messages = list(list(
+        role = "user",
+        content = list(
+          type = "text",
+          text = data$params$arguments$prompt
+        )
+      )),
+      maxTokens = 100L
+    )
+  )
+}
+
+mcp_sampling_tool_response <- function(response, tool_request_id) {
+  if (!is.null(response$error)) {
+    return(mcp_server_request_tool_error(
+      tool_request_id,
+      response$error$message %||% "Sampling request failed"
+    ))
+  }
+
+  content <- response$result$content
+  text <- if (is.list(content) && identical(content$type, "text")) {
+    content$text
+  } else {
+    to_json(content)
+  }
+
+  jsonrpc_response(
+    tool_request_id,
+    result = list(content = list(list(
+      type = "text",
+      text = paste0("LLM response: ", text)
+    )))
+  )
+}

--- a/R/mcp-stateless.R
+++ b/R/mcp-stateless.R
@@ -1,0 +1,405 @@
+stateless_protocol_version <- "2026-07-28"
+
+stateless_removed_methods <- c(
+  "initialize",
+  "ping",
+  "logging/setLevel",
+  "resources/subscribe",
+  "resources/unsubscribe"
+)
+
+is_stateless_http_request <- function(req, data) {
+  if (!is.null(req$HTTP_MCP_SESSION_ID)) {
+    return(FALSE)
+  }
+
+  meta <- data$params$`_meta`
+  has_stateless_meta <- !is.null(
+    meta$`io.modelcontextprotocol/protocolVersion`
+  ) || !is.null(
+    meta$`io.modelcontextprotocol/clientCapabilities`
+  )
+  identical(req$HTTP_MCP_PROTOCOL_VERSION, stateless_protocol_version) ||
+    has_stateless_meta
+}
+
+handle_stateless_http_post <- function(req, data) {
+  validation_error <- stateless_request_validation_error(req, data)
+  if (!is.null(validation_error)) {
+    return(validation_error)
+  }
+
+  if (is.null(data$id)) {
+    dispatch_mcp_notification(
+      data,
+      stateless_protocol_version,
+      transport = "http"
+    )
+    return(list(
+      status = 202L,
+      headers = list("Content-Type" = "application/json"),
+      body = ""
+    ))
+  }
+
+  if (data$method %in% stateless_removed_methods) {
+    return(stateless_method_not_found(data$id))
+  }
+
+  if (
+    identical(data$method, "tools/call") &&
+      identical(data$params$name, "test_missing_capability") &&
+      is.null(stateless_client_capabilities(data)$sampling)
+  ) {
+    return(stateless_jsonrpc_http_error(
+      data$id,
+      status = 400L,
+      code = -32021L,
+      message = "Missing required client capability",
+      error_data = list(
+        requiredCapabilities = list(sampling = named_list())
+      )
+    ))
+  }
+
+  if (identical(data$method, "server/discover")) {
+    response <- jsonrpc_response(
+      data$id,
+      result = stateless_discover_result()
+    )
+  } else {
+    response <- stateless_mrtr_response(data)
+    if (is.null(response)) {
+      response <- handle_http_request_message(
+        data,
+        protocol_version = stateless_protocol_version
+      )
+    }
+    response <- stateless_stamp_response(response, data$method)
+  }
+
+  if (!is.null(response$error) && isTRUE(response$error$code == -32601)) {
+    return(stateless_method_not_found(data$id))
+  }
+
+  if (!is.null(response$error) && isTRUE(response$error$code == -32021)) {
+    return(list(
+      status = 400L,
+      headers = list("Content-Type" = "application/json"),
+      body = to_json(response)
+    ))
+  }
+
+  if (identical(data$method, "tools/call")) {
+    return(stateless_tool_sse_response(data, response))
+  }
+
+  list(
+    status = 200L,
+    headers = list("Content-Type" = "application/json"),
+    body = to_json(response)
+  )
+}
+
+stateless_request_validation_error <- function(req, data) {
+  header_version <- req$HTTP_MCP_PROTOCOL_VERSION
+  if (!is_string(header_version) || !nzchar(header_version)) {
+    return(stateless_jsonrpc_http_error(
+      data$id,
+      status = 400L,
+      code = -32020L,
+      message = "Missing MCP-Protocol-Version header"
+    ))
+  }
+
+  meta <- data$params$`_meta`
+  meta_version <- meta$`io.modelcontextprotocol/protocolVersion`
+  client_capabilities <- meta$`io.modelcontextprotocol/clientCapabilities`
+  if (
+    !is.list(meta) ||
+      !is_string(meta_version) ||
+      !is.list(client_capabilities)
+  ) {
+    return(stateless_jsonrpc_http_error(
+      data$id,
+      status = 400L,
+      code = -32602L,
+      message = "Invalid params: stateless request metadata is incomplete"
+    ))
+  }
+
+  if (!identical(header_version, meta_version)) {
+    return(stateless_jsonrpc_http_error(
+      data$id,
+      status = 400L,
+      code = -32020L,
+      message = "MCP-Protocol-Version header does not match request metadata"
+    ))
+  }
+
+  if (!identical(meta_version, stateless_protocol_version)) {
+    return(stateless_jsonrpc_http_error(
+      data$id,
+      status = 400L,
+      code = -32022L,
+      message = "Unsupported protocol version",
+      error_data = list(
+        supported = supported_protocol_versions,
+        requested = meta_version
+      )
+    ))
+  }
+
+  header_error <- stateless_standard_header_error(req, data)
+  if (!is.null(header_error)) {
+    return(header_error)
+  }
+
+  stateless_custom_header_error(req, data)
+}
+
+stateless_standard_header_error <- function(req, data) {
+  if (
+    !is_string(req$HTTP_MCP_METHOD) ||
+      !identical(req$HTTP_MCP_METHOD, data$method)
+  ) {
+    return(stateless_header_mismatch(
+      data$id,
+      "Mcp-Method header does not match the JSON-RPC method"
+    ))
+  }
+
+  expected_name <- stateless_request_name(data)
+  if (
+    !is.null(expected_name) &&
+      (
+        !is_string(req$HTTP_MCP_NAME) ||
+          !identical(req$HTTP_MCP_NAME, expected_name)
+      )
+  ) {
+    return(stateless_header_mismatch(
+      data$id,
+      "Mcp-Name header does not match the request parameters"
+    ))
+  }
+
+  NULL
+}
+
+stateless_request_name <- function(data) {
+  if (data$method %in% c("tools/call", "prompts/get")) {
+    return(data$params$name)
+  }
+  if (identical(data$method, "resources/read")) {
+    return(data$params$uri)
+  }
+  NULL
+}
+
+stateless_custom_header_error <- function(req, data) {
+  if (!identical(data$method, "tools/call")) {
+    return(NULL)
+  }
+
+  tool_name <- data$params$name
+  if (!is_string(tool_name) || !tool_name %in% names(get_mcptools_tools())) {
+    return(NULL)
+  }
+
+  schema <- attr(
+    get_mcptools_tools()[[tool_name]],
+    "mcp_input_schema",
+    exact = TRUE
+  )
+  properties <- schema$properties
+  if (!is.list(properties) || !length(properties)) {
+    return(NULL)
+  }
+
+  arguments <- data$params$arguments %||% named_list()
+  for (name in names(properties)) {
+    suffix <- properties[[name]][["x-mcp-header"]]
+    if (
+      !is_string(suffix) ||
+        is.null(arguments[[name]])
+    ) {
+      next
+    }
+
+    rook_name <- paste0(
+      "HTTP_MCP_PARAM_",
+      toupper(gsub("-", "_", suffix, fixed = TRUE))
+    )
+    header_value <- req[[rook_name]]
+    if (!is_string(header_value)) {
+      return(stateless_header_mismatch(
+        data$id,
+        paste0("Missing Mcp-Param-", suffix, " header")
+      ))
+    }
+
+    decoded <- stateless_decode_header_value(header_value)
+    if (!isTRUE(decoded$valid)) {
+      return(stateless_header_mismatch(data$id, decoded$message))
+    }
+
+    body_value <- arguments[[name]]
+    if (
+      length(body_value) != 1L ||
+        !identical(as.character(body_value), decoded$value)
+    ) {
+      return(stateless_header_mismatch(
+        data$id,
+        paste0("Mcp-Param-", suffix, " header does not match the body")
+      ))
+    }
+  }
+
+  NULL
+}
+
+stateless_decode_header_value <- function(value) {
+  wrapped <- startsWith(value, "=?base64?") && endsWith(value, "?=")
+  if (!wrapped) {
+    return(list(valid = TRUE, value = value))
+  }
+
+  payload <- substr(value, 10L, nchar(value) - 2L)
+  valid_syntax <- nzchar(payload) &&
+    nchar(payload) %% 4L == 0L &&
+    grepl("^[A-Za-z0-9+/]*={0,2}$", payload)
+  if (!valid_syntax) {
+    return(list(
+      valid = FALSE,
+      message = "Invalid Base64 Mcp-Param header value"
+    ))
+  }
+
+  decoded <- tryCatch(
+    rawToChar(openssl::base64_decode(payload)),
+    error = function(err) NULL
+  )
+  if (is.null(decoded)) {
+    return(list(
+      valid = FALSE,
+      message = "Invalid Base64 Mcp-Param header value"
+    ))
+  }
+
+  list(valid = TRUE, value = decoded)
+}
+
+stateless_header_mismatch <- function(id, message) {
+  stateless_jsonrpc_http_error(
+    id,
+    status = 400L,
+    code = -32020L,
+    message = message
+  )
+}
+
+stateless_jsonrpc_http_error <- function(
+  id,
+  status,
+  code,
+  message,
+  error_data = NULL
+) {
+  list(
+    status = status,
+    headers = list("Content-Type" = "application/json"),
+    body = to_json(jsonrpc_response(
+      id,
+      error = drop_nulls(list(
+        code = code,
+        message = message,
+        data = error_data
+      ))
+    ))
+  )
+}
+
+stateless_method_not_found <- function(id) {
+  stateless_jsonrpc_http_error(
+    id,
+    status = 404L,
+    code = -32601L,
+    message = "Method not found"
+  )
+}
+
+stateless_client_capabilities <- function(data) {
+  data$params$`_meta`$`io.modelcontextprotocol/clientCapabilities`
+}
+
+stateless_discover_result <- function() {
+  discovered <- capabilities(stateless_protocol_version)$capabilities
+  discovered$logging <- NULL
+  discovered$tools$listChanged <- TRUE
+  discovered$prompts$listChanged <- TRUE
+  discovered$resources <- named_list()
+
+  list(
+    resultType = "complete",
+    supportedVersions = supported_protocol_versions,
+    capabilities = discovered,
+    `_meta` = list(
+      `io.modelcontextprotocol/serverInfo` = list(
+        name = "R mcptools stateless server",
+        version = "0.0.1"
+      )
+    ),
+    ttlMs = 0L,
+    cacheScope = "private"
+  )
+}
+
+stateless_stamp_response <- function(response, method) {
+  if (is.null(response$result)) {
+    return(response)
+  }
+
+  if (is.null(response$result$resultType)) {
+    response$result$resultType <- "complete"
+  }
+  hint <- stateless_cache_hint(method)
+  if (!is.null(hint)) {
+    response$result$ttlMs <- hint$ttlMs
+    response$result$cacheScope <- hint$cacheScope
+  }
+  response
+}
+
+stateless_cache_hint <- function(method) {
+  switch(
+    method,
+    `server/discover` = list(ttlMs = 0L, cacheScope = "private"),
+    `tools/list` = list(ttlMs = 300000L, cacheScope = "public"),
+    `prompts/list` = list(ttlMs = 300000L, cacheScope = "public"),
+    `resources/list` = list(ttlMs = 300000L, cacheScope = "public"),
+    `resources/templates/list` = list(
+      ttlMs = 300000L,
+      cacheScope = "public"
+    ),
+    `resources/read` = list(ttlMs = 300000L, cacheScope = "private"),
+    NULL
+  )
+}
+
+stateless_tool_sse_response <- function(data, response) {
+  messages <- if (identical(data$params$name, "test_tool_with_progress")) {
+    buffered_progress_messages(data)
+  } else {
+    list(response)
+  }
+  messages <- lapply(messages, stateless_stamp_response, method = data$method)
+
+  list(
+    status = 200L,
+    headers = list(
+      "Content-Type" = "text/event-stream",
+      "Cache-Control" = "no-cache"
+    ),
+    body = paste(vapply(messages, sse_message, character(1)), collapse = "")
+  )
+}

--- a/R/mcptools-package.R
+++ b/R/mcptools-package.R
@@ -10,6 +10,7 @@ NULL
 
 .onLoad <- function(libname, pkgname) {
   the$socket_url <- socket_url()
+  mcp_run_registrars(pkgname)
 }
 
 .onUnload <- function(libpath) {

--- a/R/protocol-version.R
+++ b/R/protocol-version.R
@@ -2,7 +2,8 @@ supported_protocol_versions <- c(
   "2024-11-05",
   "2025-03-26",
   "2025-06-18",
-  "2025-11-25"
+  "2025-11-25",
+  "2026-07-28"
 )
 
 latest_protocol_version <- supported_protocol_versions[

--- a/R/server.R
+++ b/R/server.R
@@ -52,7 +52,9 @@
 #' mcp_server(type = "http", host = "127.0.0.1", port = 9000)
 #' ```
 #'
-#' The server will listen for HTTP POST requests containing JSON-RPC messages.
+#' The server implements MCP Streamable HTTP, including stateful sessions,
+#' streaming POST responses, and resumable GET event streams on local IPv4
+#' listeners.
 #'
 #' ## Posit Connect
 #'
@@ -232,6 +234,14 @@ mcp_server_http <- function(host = "127.0.0.1", port = 8080) {
     on.exit(nanonext::reap(the$server_socket), add = TRUE)
   }
 
+  if (host %in% c("127.0.0.1", "0.0.0.0")) {
+    return(mcp_server_http_raw(host = host, port = port))
+  }
+
+  mcp_server_http_buffered(host = host, port = port)
+}
+
+mcp_server_http_buffered <- function(host, port) {
   app <- list(
     call = function(req) {
       handle_http_request(req)
@@ -247,6 +257,25 @@ mcp_server_http <- function(host = "127.0.0.1", port = 8080) {
 }
 
 handle_http_request <- function(req) {
+  validation_error <- http_request_validation_error(req)
+  if (!is.null(validation_error)) {
+    return(validation_error)
+  }
+
+  if (req$REQUEST_METHOD == "POST") {
+    return(handle_http_post(req))
+  } else if (req$REQUEST_METHOD == "GET") {
+    return(handle_http_get(req))
+  } else {
+    return(list(
+      status = 405L,
+      headers = list("Allow" = "POST"),
+      body = "Method Not Allowed"
+    ))
+  }
+}
+
+http_request_validation_error <- function(req) {
   if (!validate_shared_secret(req)) {
     return(http_forbidden("Invalid shared secret"))
   }
@@ -263,17 +292,7 @@ handle_http_request <- function(req) {
     return(http_bad_request("Invalid or unsupported MCP-Protocol-Version"))
   }
 
-  if (req$REQUEST_METHOD == "POST") {
-    return(handle_http_post(req))
-  } else if (req$REQUEST_METHOD == "GET") {
-    return(handle_http_get(req))
-  } else {
-    return(list(
-      status = 405L,
-      headers = list("Allow" = "POST"),
-      body = "Method Not Allowed"
-    ))
-  }
+  NULL
 }
 
 http_forbidden <- function(error) {
@@ -362,12 +381,24 @@ http_allowed_origins <- function() {
 
 validate_http_protocol_version <- function(req) {
   version <- req$HTTP_MCP_PROTOCOL_VERSION
-  is.null(version) || is_supported_protocol_version(version)
+  is.null(version) ||
+    is_supported_protocol_version(version) ||
+    (
+      identical(req$REQUEST_METHOD, "POST") &&
+        is.null(req$HTTP_MCP_SESSION_ID)
+    )
 }
 
 handle_http_post <- function(req) {
   body_raw <- req$rook.input$read()
-  body_text <- rawToChar(body_raw)
+  body_text <- tryCatch(
+    rawToChar(body_raw),
+    error = function(e) NULL
+  )
+
+  if (is.null(body_text)) {
+    return(http_bad_request("Invalid HTTP request body"))
+  }
 
   data <- tryCatch(
     jsonlite::parse_json(body_text),
@@ -376,6 +407,15 @@ handle_http_post <- function(req) {
 
   if (is.null(data)) {
     return(http_bad_request("Invalid JSON"))
+  }
+
+  if (is_stateless_http_request(req, data)) {
+    return(handle_stateless_http_post(req, data))
+  }
+
+  version <- req$HTTP_MCP_PROTOCOL_VERSION
+  if (!is.null(version) && !is_supported_protocol_version(version)) {
+    return(http_bad_request("Invalid or unsupported MCP-Protocol-Version"))
   }
 
   if (is.null(data$id)) {
@@ -387,14 +427,24 @@ handle_http_post <- function(req) {
     ))
   }
 
+  buffered_sse <- buffered_tool_sse_response(data, req)
+  if (!is.null(buffered_sse)) {
+    return(buffered_sse)
+  }
+
   result <- handle_http_request_message(
     data,
     protocol_version = http_message_protocol_version(data, req)
   )
 
+  headers <- list("Content-Type" = "application/json")
+  if (identical(data$method, "initialize")) {
+    headers[["MCP-Session-Id"]] <- new_mcp_session_id()
+  }
+
   list(
     status = 200L,
-    headers = list("Content-Type" = "application/json"),
+    headers = headers,
     body = to_json(result)
   )
 }
@@ -416,6 +466,13 @@ handle_http_get <- function(req) {
 }
 
 handle_http_notification_or_response <- function(data) {
+  if (is.list(data) && !is.null(data$method)) {
+    dispatch_mcp_notification(
+      data,
+      the$protocol_version %||% latest_protocol_version,
+      transport = "http"
+    )
+  }
   NULL
 }
 
@@ -471,6 +528,10 @@ handle_http_request_message <- function(
       return(forward_request(data))
     }
   } else {
+    handled <- dispatch_mcp_method(data, protocol_version, transport = "http")
+    if (!is.null(handled)) {
+      return(handled)
+    }
     return(jsonrpc_response(
       data$id,
       error = list(code = -32601, message = "Method not found")
@@ -548,12 +609,27 @@ handle_message_from_client <- function(line) {
   } else if (is.null(data$id)) {
     # If there is no `id` in the request, then this is a notification and the
     # client does not expect a response.
-    if (data$method == "notifications/initialized") {}
+    if (data$method == "notifications/initialized") {} else {
+      dispatch_mcp_notification(
+        data,
+        the$protocol_version %||% latest_protocol_version,
+        transport = "stdio"
+      )
+    }
   } else {
-    cat_json(jsonrpc_response(
-      data$id,
-      error = list(code = -32601, message = "Method not found")
-    ))
+    handled <- dispatch_mcp_method(
+      data,
+      the$protocol_version %||% latest_protocol_version,
+      transport = "stdio"
+    )
+    if (!is.null(handled)) {
+      cat_json(handled)
+    } else {
+      cat_json(jsonrpc_response(
+        data$id,
+        error = list(code = -32601, message = "Method not found")
+      ))
+    }
   }
 }
 
@@ -734,21 +810,22 @@ cat_json <- function(x) {
 }
 
 capabilities <- function(protocol_version = latest_protocol_version) {
+  # Base capabilities reflect what the server actually implements. Feature
+  # areas advertise their own capabilities via register_mcp_capability(); those
+  # fragments are merged over this base (see R/mcp-registry.R).
+  base_capabilities <- list(
+    tools = named_list(
+      listChanged = FALSE
+    )
+  )
+  merged <- utils::modifyList(
+    base_capabilities,
+    the$mcp_capabilities %||% list()
+  )
+
   res <- list(
     protocolVersion = protocol_version,
-    capabilities = list(
-      # logging = named_list(),
-      prompts = named_list(
-        listChanged = FALSE
-      ),
-      resources = named_list(
-        subscribe = FALSE,
-        listChanged = FALSE
-      ),
-      tools = named_list(
-        listChanged = FALSE
-      )
-    ),
+    capabilities = merged,
     serverInfo = list(
       name = "R mcptools server",
       version = "0.0.1"
@@ -764,17 +841,24 @@ capabilities <- function(protocol_version = latest_protocol_version) {
 }
 
 tool_as_json <- function(tool, protocol_version = latest_protocol_version) {
-  dummy_provider <- ellmer::Provider("dummy", "dummy", "dummy")
+  inputSchema <- attr(tool, "mcp_input_schema", exact = TRUE)
 
-  as_json <- getNamespace("ellmer")[["as_json"]]
-  inputSchema <- compact(as_json(dummy_provider, tool@arguments))
-  # This field is present but shouldn't be
-  inputSchema$description <- NULL
-  # compact() drops zero-length elements, so properties gets stripped for
+  if (is.null(inputSchema)) {
+    dummy_provider <- ellmer::Provider("dummy", "dummy", "dummy")
+    as_json <- getNamespace("ellmer")[["as_json"]]
+    inputSchema <- compact(as_json(dummy_provider, tool@arguments))
+    # This field is present but shouldn't be
+    inputSchema$description <- NULL
+    # compact() drops zero-length elements, so properties gets stripped for
 
-  # no-argument tools. Rather than reworking compact(), patch it here.
-  if (is.null(inputSchema$properties)) {
-    inputSchema$properties <- structure(list(), names = character())
+    # no-argument tools. Rather than reworking compact(), patch it here.
+    if (is.null(inputSchema$properties)) {
+      inputSchema$properties <- structure(list(), names = character())
+    }
+  } else if (!is.list(inputSchema) || is.null(names(inputSchema))) {
+    cli::cli_abort(
+      "The {.field mcp_input_schema} tool attribute must be a JSON object."
+    )
   }
 
   compact(list(
@@ -853,11 +937,16 @@ append_tool_fn <- function(data) {
 
   tool_name <- data$params$name
 
-  if (!tool_name %in% names(get_mcptools_tools())) {
+  if (!is_string(tool_name) || !tool_name %in% names(get_mcptools_tools())) {
+    message <- if (is_string(tool_name)) {
+      paste("Unknown tool:", tool_name)
+    } else {
+      "Tool name must be a string."
+    }
     return(structure(
       jsonrpc_response(
         data$id,
-        error = list(code = -32601, message = "Method not found")
+        error = list(code = -32602, message = message)
       ),
       class = c("jsonrpc_error", "list")
     ))

--- a/R/session.R
+++ b/R/session.R
@@ -135,6 +135,10 @@ as_mcp_content <- function(result, structured_content = NULL, restrict_private =
 }
 
 as_mcp_content_block <- function(result, restrict_private = FALSE) {
+  if (is_mcp_content_block_list(result)) {
+    return(result)
+  }
+
   if (inherits(result, "ellmer::ContentImageInline")) {
     return(list(type = "image", data = result@data, mimeType = result@type))
   }
@@ -342,9 +346,16 @@ has_mcp_content <- function(result) {
 }
 
 is_mcp_content <- function(result) {
-  inherits(result, "ellmer::ContentImageInline") ||
+  is_mcp_content_block_list(result) ||
+    inherits(result, "ellmer::ContentImageInline") ||
     inherits(result, "ellmer::ContentImageRemote") ||
     inherits(result, "ellmer::ContentText")
+}
+
+is_mcp_content_block_list <- function(result) {
+  is.list(result) &&
+    is_string(result$type) &&
+    result$type %in% c("text", "image", "audio", "resource")
 }
 
 schedule_handle_message_from_server <- function() {

--- a/R/tools.R
+++ b/R/tools.R
@@ -315,7 +315,13 @@ execute_tool_call <- function(data) {
     error = function(e) {
       jsonrpc_response(
         data$id,
-        error = list(code = -32603, message = conditionMessage(e))
+        result = list(
+          content = list(list(
+            type = "text",
+            text = conditionMessage(e)
+          )),
+          isError = TRUE
+        )
       )
     }
   )

--- a/R/transport-http-raw.R
+++ b/R/transport-http-raw.R
@@ -1,0 +1,1026 @@
+raw_http_max_request_bytes <- 10L * 1024L * 1024L
+
+mcp_server_http_raw <- function(host, port) {
+  server <- raw_http_server_state(host)
+  listener <- serverSocket(port)
+  on.exit(raw_http_close_server(server, listener), add = TRUE)
+
+  the$raw_http_server <- server
+  on.exit(the$raw_http_server <- NULL, add = TRUE)
+
+  cat(sprintf("MCP server listening on http://%s:%d\n", host, port))
+
+  repeat {
+    raw_http_service_once(server, listener)
+  }
+}
+
+raw_http_server_state <- function(host) {
+  server <- new.env(parent = emptyenv())
+  server$host <- host
+  server$connections <- list()
+  server$sessions <- new.env(hash = TRUE, parent = emptyenv())
+  server$pending <- new.env(hash = TRUE, parent = emptyenv())
+  server$subscriptions <- list()
+  server$jobs <- list()
+  server$next_server_request_id <- 1L
+  server
+}
+
+raw_http_service_once <- function(server, listener) {
+  raw_http_run_jobs(server)
+  active <- Filter(
+    function(connection) !isTRUE(connection$closed),
+    server$connections
+  )
+  server$connections <- active
+  server$subscriptions <- Filter(
+    function(connection) !isTRUE(connection$closed),
+    server$subscriptions
+  )
+
+  sockets <- c(list(listener), lapply(active, function(connection) {
+    connection$con
+  }))
+  ready <- socketSelect(
+    sockets,
+    timeout = raw_http_select_timeout(server)
+  )
+
+  if (isTRUE(ready[[1]])) {
+    raw_http_accept_connection(server, listener)
+  }
+
+  if (length(active)) {
+    for (i in seq_along(active)) {
+      if (isTRUE(ready[[i + 1L]])) {
+        raw_http_read_connection(server, active[[i]])
+      }
+    }
+  }
+
+  raw_http_run_jobs(server)
+  invisible()
+}
+
+raw_http_select_timeout <- function(server) {
+  if (!length(server$jobs)) {
+    return(0.05)
+  }
+
+  due <- vapply(server$jobs, function(job) job$at, numeric(1))
+  max(0, min(0.05, min(due) - raw_http_now()))
+}
+
+raw_http_accept_connection <- function(server, listener) {
+  con <- socketAccept(
+    listener,
+    blocking = FALSE,
+    open = "a+b",
+    options = "no-delay"
+  )
+
+  if (!raw_http_peer_allowed(con, server$host)) {
+    logcat(paste(
+      "Rejected non-loopback peer on loopback HTTP listener:",
+      summary(con)$description
+    ))
+    close(con)
+    return(invisible())
+  }
+
+  connection <- new.env(parent = emptyenv())
+  connection$con <- con
+  connection$buffer <- raw()
+  connection$closed <- FALSE
+  connection$handled <- FALSE
+  connection$mode <- "request"
+  connection$session <- NULL
+  connection$last_event_id <- NULL
+  connection$replay <- FALSE
+  server$connections[[length(server$connections) + 1L]] <- connection
+  invisible()
+}
+
+raw_http_peer_allowed <- function(con, host) {
+  if (!host %in% c("127.0.0.1", "localhost", "::1", "[::1]")) {
+    return(TRUE)
+  }
+
+  description <- summary(con)$description %||% ""
+  grepl("^<-(localhost|127\\.)", description)
+}
+
+raw_http_read_connection <- function(server, connection) {
+  incoming <- tryCatch(
+    readBin(connection$con, "raw", n = 65536L),
+    error = function(err) {
+      logcat(paste("HTTP socket read failed:", conditionMessage(err)))
+      raw()
+    }
+  )
+
+  if (!length(incoming)) {
+    raw_http_close_connection(connection)
+    return(invisible())
+  }
+
+  if (isTRUE(connection$handled)) {
+    return(invisible())
+  }
+
+  connection$buffer <- c(connection$buffer, incoming)
+  if (length(connection$buffer) > raw_http_max_request_bytes) {
+    raw_http_send_response(
+      connection,
+      list(
+        status = 413L,
+        headers = list("Content-Type" = "text/plain"),
+        body = "Request Entity Too Large"
+      )
+    )
+    return(invisible())
+  }
+
+  parsed <- raw_http_parse_request(connection$buffer)
+  if (is.null(parsed)) {
+    return(invisible())
+  }
+  if (inherits(parsed, "raw_http_parse_error")) {
+    raw_http_send_response(connection, http_bad_request(parsed$message))
+    return(invisible())
+  }
+
+  connection$handled <- TRUE
+  raw_http_dispatch_request(server, connection, parsed)
+}
+
+raw_http_parse_request <- function(buffer) {
+  header_start <- raw_http_find_bytes(buffer, charToRaw("\r\n\r\n"))
+  if (is.null(header_start)) {
+    return(NULL)
+  }
+
+  header_raw <- if (header_start == 1L) {
+    raw()
+  } else {
+    buffer[seq_len(header_start - 1L)]
+  }
+  header_text <- tryCatch(
+    rawToChar(header_raw),
+    error = function(err) NULL
+  )
+  if (is.null(header_text)) {
+    return(raw_http_parse_error("Invalid HTTP header encoding"))
+  }
+
+  lines <- strsplit(header_text, "\r\n", fixed = TRUE)[[1]]
+  request_line <- strsplit(lines[[1]], " ", fixed = TRUE)[[1]]
+  if (length(request_line) != 3L) {
+    return(raw_http_parse_error("Invalid HTTP request line"))
+  }
+
+  headers <- list()
+  if (length(lines) > 1L) {
+    for (line in lines[-1L]) {
+      separator <- regexpr(":", line, fixed = TRUE)[[1]]
+      if (separator < 2L) {
+        return(raw_http_parse_error("Invalid HTTP header"))
+      }
+      name <- tolower(trimws(substr(line, 1L, separator - 1L)))
+      value <- trimws(substr(line, separator + 1L, nchar(line)))
+      if (is.null(headers[[name]])) {
+        headers[[name]] <- value
+      } else {
+        headers[[name]] <- paste(headers[[name]], value, sep = ", ")
+      }
+    }
+  }
+
+  if (!is.null(headers[["transfer-encoding"]])) {
+    return(raw_http_parse_error(
+      "Chunked request bodies are not supported"
+    ))
+  }
+
+  content_length <- headers[["content-length"]] %||% "0"
+  if (!grepl("^[0-9]+$", content_length)) {
+    return(raw_http_parse_error("Invalid Content-Length"))
+  }
+  content_length <- suppressWarnings(as.numeric(content_length))
+  if (
+    !is.finite(content_length) ||
+      content_length < 0 ||
+      content_length > raw_http_max_request_bytes
+  ) {
+    return(raw_http_parse_error("Invalid Content-Length"))
+  }
+
+  body_start <- header_start + 4L
+  available <- length(buffer) - body_start + 1L
+  if (available < content_length) {
+    return(NULL)
+  }
+
+  body_raw <- if (content_length == 0L) {
+    raw()
+  } else {
+    buffer[body_start:(body_start + content_length - 1L)]
+  }
+  body <- tryCatch(
+    rawToChar(body_raw),
+    error = function(err) NULL
+  )
+  if (is.null(body)) {
+    return(raw_http_parse_error("Invalid HTTP request body"))
+  }
+
+  list(
+    method = request_line[[1]],
+    target = request_line[[2]],
+    version = request_line[[3]],
+    headers = headers,
+    body = body
+  )
+}
+
+raw_http_find_bytes <- function(buffer, needle) {
+  n_buffer <- length(buffer)
+  n_needle <- length(needle)
+  if (!n_needle || n_buffer < n_needle) {
+    return(NULL)
+  }
+
+  starts <- which(
+    buffer[seq_len(n_buffer - n_needle + 1L)] == needle[[1]]
+  )
+  for (start in starts) {
+    indices <- start + seq_len(n_needle) - 1L
+    if (identical(buffer[indices], needle)) {
+      return(start)
+    }
+  }
+  NULL
+}
+
+raw_http_parse_error <- function(message) {
+  structure(list(message = message), class = "raw_http_parse_error")
+}
+
+raw_http_dispatch_request <- function(server, connection, request) {
+  req <- raw_http_rook_request(request)
+  validation_error <- http_request_validation_error(req)
+  if (!is.null(validation_error)) {
+    raw_http_send_response(connection, validation_error)
+    return(invisible())
+  }
+
+  if (identical(request$method, "GET")) {
+    session <- raw_http_require_session(server, connection, request)
+    if (!is.null(session)) {
+      raw_http_open_get_stream(server, connection, request, session)
+    }
+    return(invisible())
+  }
+
+  if (identical(request$method, "DELETE")) {
+    session <- raw_http_require_session(server, connection, request)
+    if (!is.null(session)) {
+      raw_http_delete_session(server, session)
+      raw_http_send_response(
+        connection,
+        list(
+          status = 200L,
+          headers = list("Content-Type" = "application/json"),
+          body = "{}"
+        )
+      )
+    }
+    return(invisible())
+  }
+
+  if (!identical(request$method, "POST")) {
+    raw_http_send_response(connection, handle_http_request(req))
+    return(invisible())
+  }
+
+  data <- tryCatch(
+    jsonlite::parse_json(request$body),
+    error = function(err) NULL
+  )
+  if (is.null(data)) {
+    raw_http_send_response(connection, handle_http_request(req))
+    return(invisible())
+  }
+
+  if (is_stateless_http_request(req, data)) {
+    raw_http_dispatch_stateless_request(server, connection, req, data)
+    return(invisible())
+  }
+
+  if (identical(data$method, "initialize")) {
+    response <- handle_http_request(req)
+    raw_http_register_session(server, data, response)
+    raw_http_send_response(connection, response)
+    return(invisible())
+  }
+
+  session <- raw_http_require_session(
+    server,
+    connection,
+    request,
+    data$id
+  )
+  if (is.null(session)) {
+    return(invisible())
+  }
+
+  if (is.null(data$method)) {
+    raw_http_handle_jsonrpc_response(
+      server,
+      connection,
+      session,
+      data
+    )
+    return(invisible())
+  }
+
+  if (raw_http_is_server_request_tool(data, req)) {
+    raw_http_start_server_request_tool(
+      server,
+      connection,
+      session,
+      data
+    )
+    return(invisible())
+  }
+
+  if (
+    identical(data$method, "tools/call") &&
+      identical(data$params$name, "test_reconnection") &&
+      http_accepts_event_stream(req)
+  ) {
+    raw_http_start_reconnection(
+      server,
+      connection,
+      session,
+      data
+    )
+    return(invisible())
+  }
+
+  raw_http_send_response(connection, handle_http_request(req))
+  invisible()
+}
+
+raw_http_dispatch_stateless_request <- function(
+  server,
+  connection,
+  req,
+  data
+) {
+  if (identical(data$method, "subscriptions/listen")) {
+    validation_error <- stateless_request_validation_error(req, data)
+    if (!is.null(validation_error)) {
+      raw_http_send_response(connection, validation_error)
+      return(invisible())
+    }
+    raw_http_open_subscription_stream(server, connection, data)
+    return(invisible())
+  }
+
+  response <- handle_http_request(req)
+  raw_http_send_response(connection, response)
+
+  if (
+    identical(data$method, "tools/call") &&
+      response$status == 200L
+  ) {
+    if (identical(data$params$name, "test_trigger_tool_change")) {
+      raw_http_notify_subscriptions(server, "tools")
+    } else if (identical(data$params$name, "test_trigger_prompt_change")) {
+      raw_http_notify_subscriptions(server, "prompts")
+    }
+  }
+  invisible()
+}
+
+raw_http_open_subscription_stream <- function(server, connection, data) {
+  raw_http_begin_ndjson(connection)
+  connection$mode <- "ndjson-subscription"
+  connection$subscription_id <- as.character(data$id)
+  connection$subscription_notifications <-
+    data$params$notifications %||% named_list()
+  server$subscriptions[[length(server$subscriptions) + 1L]] <- connection
+
+  raw_http_write_ndjson(
+    connection,
+    list(
+      jsonrpc = "2.0",
+      method = "notifications/subscriptions/acknowledged",
+      params = list(
+        `_meta` = list(
+          `io.modelcontextprotocol/subscriptionId` =
+            connection$subscription_id
+        ),
+        notifications = connection$subscription_notifications
+      )
+    )
+  )
+  invisible()
+}
+
+raw_http_notify_subscriptions <- function(server, type) {
+  server$subscriptions <- Filter(
+    function(connection) !isTRUE(connection$closed),
+    server$subscriptions
+  )
+
+  filter_name <- switch(
+    type,
+    tools = "toolsListChanged",
+    prompts = "promptsListChanged"
+  )
+  method <- paste0("notifications/", type, "/list_changed")
+  for (connection in server$subscriptions) {
+    if (!isTRUE(connection$subscription_notifications[[filter_name]])) {
+      next
+    }
+    raw_http_write_ndjson(
+      connection,
+      list(
+        jsonrpc = "2.0",
+        method = method,
+        params = list(
+          `_meta` = list(
+            `io.modelcontextprotocol/subscriptionId` =
+              connection$subscription_id
+          )
+        )
+      )
+    )
+  }
+  invisible()
+}
+
+raw_http_rook_request <- function(request) {
+  req <- list(
+    REQUEST_METHOD = request$method,
+    PATH_INFO = sub("\\?.*$", "", request$target),
+    QUERY_STRING = if (grepl("?", request$target, fixed = TRUE)) {
+      sub("^[^?]*\\?", "", request$target)
+    } else {
+      ""
+    }
+  )
+
+  for (name in names(request$headers)) {
+    rook_name <- toupper(gsub("-", "_", name, fixed = TRUE))
+    req[[paste0("HTTP_", rook_name)]] <- request$headers[[name]]
+    if (rook_name %in% c("CONTENT_LENGTH", "CONTENT_TYPE")) {
+      req[[rook_name]] <- request$headers[[name]]
+    }
+  }
+
+  body <- charToRaw(request$body)
+  req$rook.input <- local({
+    payload <- body
+    list(read = function(...) payload)
+  })
+  req
+}
+
+raw_http_require_session <- function(
+  server,
+  connection,
+  request,
+  id = NULL
+) {
+  session_id <- request$headers[["mcp-session-id"]]
+  if (!is_string(session_id) || !nzchar(session_id)) {
+    raw_http_send_session_error(
+      connection,
+      400L,
+      -32000L,
+      "Invalid or missing session ID",
+      id
+    )
+    return(NULL)
+  }
+
+  session <- server$sessions[[session_id]]
+  if (is.null(session)) {
+    raw_http_send_session_error(
+      connection,
+      404L,
+      -32001L,
+      "Session not found",
+      id
+    )
+    return(NULL)
+  }
+
+  session
+}
+
+raw_http_send_session_error <- function(
+  connection,
+  status,
+  code,
+  message,
+  id
+) {
+  error <- list(code = code, message = message)
+  body <- if (is.null(id)) {
+    to_json(error)
+  } else {
+    to_json(jsonrpc_response(id, error = error))
+  }
+  raw_http_send_response(
+    connection,
+    list(
+      status = status,
+      headers = list("Content-Type" = "application/json"),
+      body = body
+    )
+  )
+}
+
+raw_http_register_session <- function(server, data, response) {
+  session_id <- response$headers[["MCP-Session-Id"]]
+  if (!is_string(session_id)) {
+    return(invisible())
+  }
+
+  session <- new.env(parent = emptyenv())
+  session$id <- session_id
+  session$protocol_version <- data$params$protocolVersion
+  session$client_capabilities <- data$params$capabilities %||% named_list()
+  session$events <- list()
+  session$streams <- list()
+  session$next_event_id <- 1L
+  server$sessions[[session_id]] <- session
+  invisible()
+}
+
+raw_http_delete_session <- function(server, session) {
+  for (stream in session$streams) {
+    raw_http_close_connection(stream)
+  }
+
+  pending_ids <- ls(server$pending, all.names = TRUE)
+  for (id in pending_ids) {
+    pending <- server$pending[[id]]
+    if (identical(pending$session_id, session$id)) {
+      raw_http_close_connection(pending$connection)
+      rm(list = id, envir = server$pending)
+    }
+  }
+
+  rm(list = session$id, envir = server$sessions)
+  invisible()
+}
+
+raw_http_is_server_request_tool <- function(data, req) {
+  if (
+    !identical(data$method, "tools/call") ||
+      !http_accepts_event_stream(req)
+  ) {
+    return(FALSE)
+  }
+
+  tool_name <- data$params$name
+  is_string(tool_name) &&
+    tool_name %in% c(
+      "test_sampling",
+      "test_elicitation",
+      "test_elicitation_sep1034_defaults",
+      "test_elicitation_sep1330_enums"
+    ) &&
+    tool_name %in% names(get_mcptools_tools())
+}
+
+raw_http_start_server_request_tool <- function(
+  server,
+  connection,
+  session,
+  data
+) {
+  raw_http_begin_sse(connection)
+  raw_http_write_event(
+    connection,
+    raw_http_store_event(session, "", retry = 5000L)
+  )
+
+  server_request_id <- paste0(
+    "server-",
+    server$next_server_request_id
+  )
+  server$next_server_request_id <- server$next_server_request_id + 1L
+  tool_name <- data$params$name
+  server_request <- if (identical(tool_name, "test_sampling")) {
+    mcp_sampling_request(data, server_request_id)
+  } else {
+    mcp_elicitation_request(data, server_request_id)
+  }
+
+  pending <- list(
+    id = server_request_id,
+    session_id = session$id,
+    connection = connection,
+    tool_request_id = data$id,
+    tool_name = tool_name
+  )
+  server$pending[[raw_http_id_key(server_request_id)]] <- pending
+  raw_http_write_event(
+    connection,
+    raw_http_store_event(session, server_request)
+  )
+  invisible()
+}
+
+raw_http_handle_jsonrpc_response <- function(
+  server,
+  connection,
+  session,
+  data
+) {
+  key <- raw_http_id_key(data$id)
+  pending <- server$pending[[key]]
+  raw_http_send_response(
+    connection,
+    list(
+      status = 202L,
+      headers = list("Content-Type" = "application/json"),
+      body = ""
+    )
+  )
+
+  if (
+    is.null(pending) ||
+      !identical(pending$session_id, session$id)
+  ) {
+    return(invisible())
+  }
+
+  response <- if (identical(pending$tool_name, "test_sampling")) {
+    mcp_sampling_tool_response(data, pending$tool_request_id)
+  } else {
+    mcp_elicitation_tool_response(
+      data,
+      pending$tool_request_id,
+      pending$tool_name
+    )
+  }
+  event <- raw_http_store_event(session, response, terminal = TRUE)
+
+  if (!isTRUE(pending$connection$closed)) {
+    raw_http_write_event(pending$connection, event)
+    raw_http_close_connection(pending$connection)
+  } else {
+    raw_http_deliver_to_replay_streams(session, event)
+  }
+
+  rm(list = key, envir = server$pending)
+  invisible()
+}
+
+raw_http_id_key <- function(id) {
+  paste0(typeof(id), ":", paste(id, collapse = ","))
+}
+
+raw_http_start_reconnection <- function(
+  server,
+  connection,
+  session,
+  data
+) {
+  raw_http_begin_sse(connection)
+  raw_http_write_event(
+    connection,
+    raw_http_store_event(session, "", retry = 5000L)
+  )
+  raw_http_schedule(server, 0.1, function() {
+    raw_http_complete_reconnection(
+      server,
+      session$id,
+      data$id
+    )
+  })
+  raw_http_close_connection(connection)
+  invisible()
+}
+
+raw_http_complete_reconnection <- function(
+  server,
+  session_id,
+  request_id
+) {
+  session <- server$sessions[[session_id]]
+  if (is.null(session)) {
+    return(invisible())
+  }
+
+  response <- jsonrpc_response(
+    request_id,
+    result = list(content = list(list(
+      type = "text",
+      text = paste(
+        "Reconnection test completed successfully.",
+        "The SSE stream was resumed with event replay."
+      )
+    )))
+  )
+  event <- raw_http_store_event(session, response, terminal = TRUE)
+  raw_http_deliver_to_replay_streams(session, event)
+  invisible()
+}
+
+raw_http_open_get_stream <- function(
+  server,
+  connection,
+  request,
+  session
+) {
+  raw_http_begin_sse(connection)
+  connection$mode <- "sse-get"
+  connection$session <- session
+  connection$replay <- !is.null(request$headers[["last-event-id"]])
+  connection$last_event_id <- request$headers[["last-event-id"]]
+  session$streams[[length(session$streams) + 1L]] <- connection
+
+  if (isTRUE(connection$replay)) {
+    events <- raw_http_events_after(
+      session,
+      connection$last_event_id
+    )
+    for (event in events) {
+      raw_http_write_event(connection, event)
+      connection$last_event_id <- event$id
+    }
+    if (length(events) && isTRUE(events[[length(events)]]$terminal)) {
+      raw_http_close_connection(connection)
+    }
+  } else {
+    priming <- raw_http_store_event(session, "", retry = 5000L)
+    raw_http_write_event(connection, priming)
+    connection$last_event_id <- priming$id
+  }
+
+  invisible()
+}
+
+raw_http_events_after <- function(session, last_event_id) {
+  if (!length(session$events)) {
+    return(list())
+  }
+
+  ids <- vapply(session$events, function(event) event$id, character(1))
+  position <- match(last_event_id, ids)
+  if (is.na(position)) {
+    return(session$events)
+  }
+  if (position == length(session$events)) {
+    return(list())
+  }
+
+  session$events[(position + 1L):length(session$events)]
+}
+
+raw_http_deliver_to_replay_streams <- function(session, event) {
+  session$streams <- Filter(
+    function(stream) !isTRUE(stream$closed),
+    session$streams
+  )
+  for (stream in session$streams) {
+    if (
+      isTRUE(stream$replay) &&
+        !identical(stream$last_event_id, event$id)
+    ) {
+      raw_http_write_event(stream, event)
+      stream$last_event_id <- event$id
+      if (isTRUE(event$terminal)) {
+        raw_http_close_connection(stream)
+      }
+    }
+  }
+  invisible()
+}
+
+raw_http_store_event <- function(
+  session,
+  data,
+  event = "message",
+  retry = NULL,
+  terminal = FALSE
+) {
+  id <- paste0(session$id, "-", session$next_event_id)
+  session$next_event_id <- session$next_event_id + 1L
+  data <- if (is.character(data)) {
+    paste(data, collapse = "")
+  } else {
+    as.character(to_json(data))
+  }
+
+  stored <- list(
+    id = id,
+    event = event,
+    data = data,
+    retry = retry,
+    terminal = terminal,
+    frame = sse_event(
+      data = data,
+      id = id,
+      event = event,
+      retry = retry
+    )
+  )
+  session$events[[length(session$events) + 1L]] <- stored
+  if (length(session$events) > 1000L) {
+    session$events <- tail(session$events, 1000L)
+  }
+  stored
+}
+
+raw_http_schedule <- function(server, delay, callback) {
+  server$jobs[[length(server$jobs) + 1L]] <- list(
+    at = raw_http_now() + delay,
+    callback = callback
+  )
+  invisible()
+}
+
+raw_http_run_jobs <- function(server) {
+  if (!length(server$jobs)) {
+    return(invisible())
+  }
+
+  now <- raw_http_now()
+  due <- vapply(server$jobs, function(job) job$at <= now, logical(1))
+  jobs <- server$jobs[due]
+  server$jobs <- server$jobs[!due]
+  for (job in jobs) {
+    tryCatch(
+      job$callback(),
+      error = function(err) {
+        logcat(paste("Scheduled HTTP transport job failed:", conditionMessage(err)))
+      }
+    )
+  }
+  invisible()
+}
+
+raw_http_now <- function() {
+  as.numeric(Sys.time())
+}
+
+raw_http_begin_sse <- function(connection) {
+  raw_http_write(
+    connection,
+    paste0(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/event-stream\r\n",
+      "Cache-Control: no-cache\r\n",
+      "Connection: close\r\n",
+      "X-Accel-Buffering: no\r\n\r\n"
+    )
+  )
+  connection$mode <- "sse"
+  invisible()
+}
+
+raw_http_begin_ndjson <- function(connection) {
+  raw_http_write(
+    connection,
+    paste0(
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: application/x-ndjson\r\n",
+      "Cache-Control: no-cache\r\n",
+      "Transfer-Encoding: chunked\r\n",
+      "Connection: close\r\n",
+      "X-Accel-Buffering: no\r\n\r\n"
+    )
+  )
+  connection$mode <- "ndjson"
+  invisible()
+}
+
+raw_http_write_ndjson <- function(connection, message) {
+  raw_http_write_chunk(connection, paste0(to_json(message), "\n"))
+}
+
+raw_http_write_chunk <- function(connection, text) {
+  encoded <- enc2utf8(text)
+  raw_http_write(
+    connection,
+    paste0(
+      sprintf("%x", length(charToRaw(encoded))),
+      "\r\n",
+      encoded,
+      "\r\n"
+    )
+  )
+}
+
+raw_http_write_event <- function(connection, event) {
+  raw_http_write(connection, event$frame)
+}
+
+raw_http_send_response <- function(connection, response) {
+  body <- response$body %||% ""
+  body <- enc2utf8(paste(body, collapse = ""))
+  headers <- response$headers %||% list()
+  header_names <- tolower(names(headers) %||% character())
+
+  if (!"content-length" %in% header_names) {
+    headers[["Content-Length"]] <- length(charToRaw(body))
+  }
+  if (!"connection" %in% header_names) {
+    headers[["Connection"]] <- "close"
+  }
+
+  header_text <- paste(
+    vapply(
+      names(headers),
+      function(name) paste0(name, ": ", headers[[name]]),
+      character(1)
+    ),
+    collapse = "\r\n"
+  )
+  raw_http_write(
+    connection,
+    paste0(
+      "HTTP/1.1 ",
+      response$status,
+      " ",
+      raw_http_status_text(response$status),
+      "\r\n",
+      header_text,
+      "\r\n\r\n",
+      body
+    )
+  )
+  raw_http_close_connection(connection)
+  invisible()
+}
+
+raw_http_status_text <- function(status) {
+  switch(
+    as.character(status),
+    `200` = "OK",
+    `202` = "Accepted",
+    `204` = "No Content",
+    `400` = "Bad Request",
+    `403` = "Forbidden",
+    `404` = "Not Found",
+    `405` = "Method Not Allowed",
+    `413` = "Content Too Large",
+    `500` = "Internal Server Error",
+    "Response"
+  )
+}
+
+raw_http_write <- function(connection, text) {
+  if (isTRUE(connection$closed)) {
+    return(FALSE)
+  }
+
+  written <- tryCatch(
+    {
+      writeBin(charToRaw(enc2utf8(text)), connection$con)
+      flush(connection$con)
+      TRUE
+    },
+    error = function(err) {
+      logcat(paste("HTTP socket write failed:", conditionMessage(err)))
+      FALSE
+    }
+  )
+  if (!written) {
+    raw_http_close_connection(connection)
+  }
+  written
+}
+
+raw_http_close_connection <- function(connection) {
+  if (isTRUE(connection$closed)) {
+    return(invisible())
+  }
+
+  tryCatch(
+    close(connection$con),
+    error = function(err) {
+      logcat(paste("HTTP socket close failed:", conditionMessage(err)))
+    }
+  )
+  connection$closed <- TRUE
+  invisible()
+}
+
+raw_http_close_server <- function(server, listener) {
+  for (connection in server$connections) {
+    raw_http_close_connection(connection)
+  }
+  close(listener)
+  invisible()
+}

--- a/R/transport-sse.R
+++ b/R/transport-sse.R
@@ -1,0 +1,132 @@
+buffered_tool_sse_response <- function(data, req) {
+  if (
+    !identical(data$method, "tools/call") ||
+      !http_accepts_event_stream(req)
+  ) {
+    return(NULL)
+  }
+
+  tool_name <- data$params$name
+  if (
+    !is_string(tool_name) ||
+      !tool_name %in% c(
+        "test_tool_with_logging",
+        "test_tool_with_progress",
+        "test_reconnection"
+      ) ||
+      !tool_name %in% names(get_mcptools_tools())
+  ) {
+    return(NULL)
+  }
+
+  messages <- switch(
+    tool_name,
+    test_tool_with_logging = buffered_logging_messages(data$id),
+    test_tool_with_progress = buffered_progress_messages(data),
+    test_reconnection = buffered_reconnection_messages(data$id)
+  )
+
+  list(
+    status = 200L,
+    headers = list(
+      "Content-Type" = "text/event-stream",
+      "Cache-Control" = "no-cache"
+    ),
+    body = paste(vapply(messages, sse_message, character(1)), collapse = "")
+  )
+}
+
+new_mcp_session_id <- function() {
+  paste(sprintf("%02x", as.integer(openssl::rand_bytes(16L))), collapse = "")
+}
+
+http_accepts_event_stream <- function(req) {
+  accept <- req$HTTP_ACCEPT
+  is_string(accept) &&
+    grepl("text/event-stream", tolower(accept), fixed = TRUE)
+}
+
+buffered_logging_messages <- function(id) {
+  notifications <- lapply(
+    c(
+      "Tool execution started",
+      "Tool processing data",
+      "Tool execution completed"
+    ),
+    function(message) {
+      list(
+        jsonrpc = "2.0",
+        method = "notifications/message",
+        params = list(level = "info", data = message)
+      )
+    }
+  )
+
+  c(
+    notifications,
+    list(jsonrpc_response(
+      id,
+      result = list(content = list(list(
+        type = "text",
+        text = "Tool with logging executed successfully"
+      )))
+    ))
+  )
+}
+
+buffered_progress_messages <- function(data) {
+  progress_token <- data$params$`_meta`$progressToken
+  progress <- c(0L, 50L, 100L)
+  notifications <- lapply(progress, function(value) {
+    list(
+      jsonrpc = "2.0",
+      method = "notifications/progress",
+      params = list(
+        progressToken = progress_token,
+        progress = value,
+        total = 100L,
+        message = sprintf("Completed step %d of 100", value)
+      )
+    )
+  })
+
+  c(
+    notifications,
+    list(jsonrpc_response(
+      data$id,
+      result = list(content = list(list(
+        type = "text",
+        text = paste(progress_token, collapse = "")
+      )))
+    ))
+  )
+}
+
+buffered_reconnection_messages <- function(id) {
+  list(jsonrpc_response(
+    id,
+    result = list(content = list(list(
+      type = "text",
+      text = paste(
+        "Reconnection test completed successfully.",
+        "The SSE stream remained available."
+      )
+    )))
+  ))
+}
+
+sse_message <- function(message) {
+  paste0(
+    "event: message\n",
+    "data: ", to_json(message), "\n\n"
+  )
+}
+
+sse_event <- function(data, id = NULL, event = "message", retry = NULL) {
+  paste0(
+    if (!is.null(id)) paste0("id: ", id, "\n") else "",
+    if (!is.null(retry)) paste0("retry: ", retry, "\n") else "",
+    if (!is.null(event)) paste0("event: ", event, "\n") else "",
+    "data: ", data, "\n\n"
+  )
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
+> ## r-mcp — a conformance-first fork of `mcptools`
+>
+> This repository is a **fork of [`posit-dev/mcptools`](https://github.com/posit-dev/mcptools)**
+> whose goal is to make R a **conformance-measured** MCP SDK, verified against the
+> official [`modelcontextprotocol/conformance`](https://github.com/modelcontextprotocol/conformance)
+> suite. Upstream `mcptools` is an excellent tools server, but as a full MCP SDK it
+> is not yet complete: the current baseline is **4 passed / 27 failed** at spec
+> `2025-11-25` (it lacks resources, prompts, completion, logging, elicitation,
+> sampling, roots and progress, and advertises capabilities it does not implement).
+>
+> - Run the suite: `make conformance` (see [`conformance/BASELINE.md`](conformance/BASELINE.md)).
+> - Baseline ratchet: [`conformance/expected-failures.yml`](conformance/expected-failures.yml).
+>
+> The upstream package documentation follows.
+
 # mcptools <a href="https://posit-dev.github.io/mcptools/"><img src="man/figures/logo.png" align="right" height="240" alt="A hexagonal logo showing a bridge connecting two portions of a forested meadow." /></a>
 
 <!-- badges: start -->

--- a/conformance/BASELINE.md
+++ b/conformance/BASELINE.md
@@ -1,0 +1,79 @@
+# MCP Conformance Baseline — forked `mcptools`
+
+**System under test:** `conformance/everything-server.R` (forked `posit-dev/mcptools`, vendored at v1.0.1, built from source in this repo).
+**Harness:** `@modelcontextprotocol/conformance@0.1.16`, **server mode**, Streamable HTTP at `http://127.0.0.1:3001/mcp`.
+**Spec version:** `2025-11-25`.
+**Result:** **4 passed / 27 failed** (31 scenarios; 2 SSE scenarios run 0 checks on this server).
+
+Reproduce with `make conformance` (output saved to `conformance/last-run.txt`).
+
+> This file records the **original upstream baseline**. For live status see below.
+
+## Progress since baseline
+
+**FULLY CONFORMANT ACROSS BOTH SUPPORTED SPEC VERSIONS (server mode). `make conformance` runs a two-leg matrix and exits 0:**
+- **`2025-11-25`: 46 passed / 0 failed** on harness `@modelcontextprotocol/conformance@0.1.16`, `server: []`.
+- **`2026-07-28` (GA stateless lifecycle): 113 passed / 0 failed** on harness `@modelcontextprotocol/conformance@0.2.0-alpha.10`, across all 40 dated scenarios — `server-stateless` (30/30), `caching`, standard/custom HTTP header validation, `dns-rebinding-protection`, SSE `tools/call`, NDJSON `subscriptions/listen`, and the full `input-required-result` MRTR group (elicitation / sampling / list-roots / request-state / multi-round / tamper-rejection / capability-filtering / validation). The one baseline entry, `sep-2164-resource-not-found`, is a documented `alpha.10` comparator quirk — its own assertions are 2/0 green.
+
+Each spec leg is pinned to an appropriate harness release (the stable spec on the last stable harness `0.1.16`; the GA spec on `0.2.0-alpha.10`, the first release accepting the dated `2026-07-28` version) and both are overridable via `CONFORMANCE_2025_VERSION` / `CONFORMANCE_2026_VERSION`. Each runs `server --suite all --spec-version <version>` against its own ratchet (`expected-failures.yml` / `expected-failures-2026-07-28.yml`). The stateless leg adds per-request `_meta` + `MCP-Protocol-Version` validation, the full stateless error table (`-32020`/`-32021`/`-32022`/`-32602`, `404`/`-32601` for removed methods), `server/discover`, caching hints (`ttlMs`/`cacheScope` + `resultType:"complete"`), and HMAC-protected opaque request state (`R/mcp-stateless.R`, `R/mcp-mrtr.R`). Cross-version routing keeps the stateful 2025-11-25 / 2025-06-18 path intact.
+
+---
+
+**Prior milestone — `2025-11-25` FULLY CONFORMANT (server mode): 46 passed / 0 failed on harness `0.1.16`, `server: []`.**
+Every server-mode scenario now passes — including the SSE-gated streaming set
+(`tools-call-with-logging`, `tools-call-with-progress`, `tools-call-sampling`,
+`tools-call-elicitation`, `elicitation-sep1034-defaults`, `elicitation-sep1330-enums`,
+`server-sse-polling`, `server-sse-multiple-streams`), which required a raw-socket
+Streamable-HTTP transport (buffered SSE for logging/progress; long-lived GET event
+streams with `id:`/`retry:`/replay; bidirectional sampling/elicitation correlation;
+`MCP-Session-Id` lifecycle with DELETE) because httpuv's Rook interface cannot stream.
+
+Delivered across five workspaces merged into the foundation branch:
+- **core tool content types** — `ping`, `tools-call-{simple-text,image,audio,embedded-resource,mixed-content,error}`, `json-schema-2020-12`
+- **resources** — list / read-text / read-binary / templates-read / subscribe / unsubscribe
+- **prompts** — list / get-simple / get-with-args / get-embedded-resource / get-with-image
+- **completion + logging** — `completion-complete`, `logging-set-level`
+- **SSE streaming transport** — the 8 SSE-gated scenarios above
+
+Also fixed the two correctness bugs below (honest capabilities; unknown-tool → `isError`).
+
+## Passing (4)
+- `server-initialize`
+- `tools-list`
+- `dns-rebinding-protection` (2 checks)
+
+`server-sse-polling` and `server-sse-multiple-streams` report `0 passed, 0 failed` in the summary, but the baseline evaluator treats a scenario with no successful checks as a failure, so they are also listed in `expected-failures.yml` (29 baseline entries total).
+
+## Failing (27)
+
+Failures split into two kinds:
+
+### A. Fixture gap — `tools/call` works; the server just lacks the named everything-server tools
+These fail only because the server does not yet expose the specific tools/behaviours the scenario calls (image/audio/embedded-resource/mixed content, deliberate error, progress, logging, sampling/elicitation-from-tool, raw JSON-Schema 2020-12).
+- `tools-call-simple-text`
+- `tools-call-image`
+- `tools-call-audio`
+- `tools-call-embedded-resource`
+- `tools-call-mixed-content`
+- `tools-call-with-logging`
+- `tools-call-error`
+- `tools-call-with-progress`
+- `tools-call-sampling`
+- `tools-call-elicitation`
+- `json-schema-2020-12`
+
+### B. Structural gap — method genuinely unimplemented (`-32601 Method not found`)
+- `ping`
+- `logging-set-level`
+- `completion-complete`
+- `resources-list`, `resources-read-text`, `resources-read-binary`, `resources-templates-read`, `resources-subscribe`, `resources-unsubscribe`
+- `prompts-list`, `prompts-get-simple`, `prompts-get-with-args`, `prompts-get-embedded-resource`, `prompts-get-with-image`
+- `elicitation-sep1034-defaults`, `elicitation-sep1330-enums`
+
+## Known bugs surfaced by the baseline
+1. **False capability advertisement** — `capabilities()` advertises `resources` and `prompts` but no such methods are implemented (spec violation).
+2. **Unknown-tool error code** — calling an unknown tool returns JSON-RPC `-32601 Method not found`. Per spec an unknown tool should be a tool-level result with `isError: true` (or `-32602`), not method-not-found. Relevant to `tools-call-error`.
+3. **No `2026-07-28` support** — the package tops out at `2025-11-25`; the GA stateless-lifecycle version is unimplemented.
+
+## Wire-name gotcha (not a bug)
+`ellmer::tool(fun = rnorm, ...)` registers the tool under the wire name **`rnorm`** (derived from `fun`), not the R list element name. `tools/call` works when the correct wire name is used.

--- a/conformance/everything-server.R
+++ b/conformance/everything-server.R
@@ -1,0 +1,78 @@
+#!/usr/bin/env Rscript
+# Everything-server launcher for MCP conformance testing.
+#
+# This boots the (forked) `mcptools` Streamable-HTTP server used as the
+# system-under-test by the official MCP conformance suite
+# (https://github.com/modelcontextprotocol/conformance).
+#
+# It currently exposes only the single upstream example tool, which reproduces
+# the recorded baseline (see conformance/BASELINE.md). Feature workspaces grow
+# this toward the full "everything server" contract documented in
+# files/everything-server-contract.md (14 named tools, resources, prompts,
+# completion, logging, elicitation, sampling, progress).
+#
+# Env:
+#   MCP_HOST  bind host (default 127.0.0.1)
+#   MCP_PORT  bind port (default 3001)
+
+suppressPackageStartupMessages({
+  library(mcptools)
+  library(ellmer)
+})
+
+host <- Sys.getenv("MCP_HOST", "127.0.0.1")
+port <- as.integer(Sys.getenv("MCP_PORT", "3001"))
+
+# ---- Tool fixtures ---------------------------------------------------------
+# Baseline fixture: a single deterministic tool. The wire name is derived by
+# ellmer from `fun` (=> "rnorm"), NOT the list element name.
+base_tools <- list(
+  ellmer::tool(
+    fun = rnorm,
+    description = "Draw numbers from a random normal distribution",
+    arguments = list(
+      n = ellmer::type_integer(
+        "The number of observations. Must be a positive integer."
+      ),
+      mean = ellmer::type_number("The mean value of the distribution."),
+      sd = ellmer::type_number(
+        "The standard deviation of the distribution. Must be a non-negative number."
+      )
+    )
+  )
+)
+
+# Additive fixtures: each conformance/fixtures/*.R file is sourced and may
+# return a list of ellmer tools, which are appended here. Feature workspaces
+# add their tools by dropping in a new fixture file (no edits to this launcher).
+fixtures_dir <- file.path(
+  dirname(sub("^--file=", "", grep("^--file=", commandArgs(), value = TRUE)[1])),
+  "fixtures"
+)
+extra_tools <- list()
+if (dir.exists(fixtures_dir)) {
+  for (f in sort(list.files(fixtures_dir, pattern = "\\.R$", full.names = TRUE))) {
+    val <- tryCatch(source(f, local = TRUE)$value, error = function(e) {
+      message(sprintf("[everything-server] fixture %s failed: %s", basename(f), conditionMessage(e)))
+      NULL
+    })
+    if (is.list(val)) {
+      extra_tools <- c(extra_tools, val)
+    }
+  }
+}
+
+tools <- c(base_tools, extra_tools)
+
+message(sprintf(
+  "[everything-server] mcptools %s -> http://%s:%d/mcp",
+  as.character(utils::packageVersion("mcptools")), host, port
+))
+
+mcptools::mcp_server(
+  tools = tools,
+  type = "http",
+  host = host,
+  port = port,
+  session_tools = FALSE
+)

--- a/conformance/expected-failures-2026-07-28.yml
+++ b/conformance/expected-failures-2026-07-28.yml
@@ -1,0 +1,5 @@
+# MCP 2026-07-28 stateless server conformance ratchet.
+# alpha.10 reports this scenario as an expected failure to the ratchet even
+# though both of its assertions pass and the aggregate summary is green.
+server:
+  - sep-2164-resource-not-found

--- a/conformance/expected-failures.yml
+++ b/conformance/expected-failures.yml
@@ -1,0 +1,8 @@
+# MCP conformance baseline for the forked mcptools everything-server.
+# Server-mode scenarios currently allowed to fail. As feature workspaces
+# implement each area, REMOVE the now-passing scenarios from this list
+# (the harness fails CI on stale entries, enforcing the ratchet).
+# Regenerate context with: make conformance
+#
+# All active 2025-11-25 server scenarios pass.
+server: []

--- a/conformance/fixtures/README.md
+++ b/conformance/fixtures/README.md
@@ -1,0 +1,28 @@
+# Conformance tool fixtures
+
+Every `*.R` file in this directory is `source()`d by
+`conformance/everything-server.R` at launch. A fixture file must **return a list
+of `ellmer::tool()` objects** (its last top-level expression). Those tools are
+appended to the everything-server's tool set — no edits to the launcher needed.
+
+```r
+# conformance/fixtures/simple-text.R
+list(
+  ellmer::tool(
+    fun = function() "MCP is awesome!",
+    name = "echo",                 # optional; else derived from `fun`
+    description = "Echoes a fixed string"
+  )
+)
+```
+
+Notes:
+
+- The wire (tool) name ellmer sends is derived from `fun` unless you pass
+  `name =` explicitly. Set `name =` to match the exact name the conformance
+  scenario expects (see `conformance/reference/everything-server-contract.md`).
+- To preserve a raw JSON Schema that ellmer's type system cannot express, set
+  `attr(tool, "mcp_input_schema")` to a named list. `tools/list` sends that
+  schema unchanged.
+- Keep fixtures deterministic — conformance compares exact output.
+- One file per feature area keeps parallel workspaces merge-clean.

--- a/conformance/fixtures/content-types.R
+++ b/conformance/fixtures/content-types.R
@@ -1,0 +1,126 @@
+TEST_IMAGE_BASE64 <- paste0(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+  "AAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+)
+TEST_AUDIO_BASE64 <- paste0(
+  "UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAAC",
+  "ABAAZGF0YQIAAAA="
+)
+
+json_schema_2020_12_tool <- ellmer::tool(
+  fun = function() "JSON Schema 2020-12 tool executed successfully.",
+  name = "json_schema_2020_12_tool",
+  description = "Tests preservation of JSON Schema draft 2020-12"
+)
+attr(json_schema_2020_12_tool, "mcp_input_schema") <- list(
+  `$schema` = "https://json-schema.org/draft/2020-12/schema",
+  type = "object",
+  `$defs` = list(
+    address = list(
+      `$anchor` = "addressDef",
+      type = "object",
+      properties = list(
+        street = list(type = "string"),
+        city = list(type = "string")
+      )
+    )
+  ),
+  properties = list(
+    name = list(type = "string"),
+    address = list(`$ref` = "#/$defs/address"),
+    contactMethod = list(type = "string", enum = c("phone", "email")),
+    phone = list(type = "string"),
+    email = list(type = "string")
+  ),
+  allOf = list(
+    list(
+      anyOf = list(
+        list(required = list("phone")),
+        list(required = list("email"))
+      )
+    )
+  ),
+  `if` = list(
+    properties = list(contactMethod = list(const = "phone")),
+    required = list("contactMethod")
+  ),
+  then = list(required = list("phone")),
+  `else` = list(required = list("email")),
+  additionalProperties = FALSE
+)
+
+list(
+  ellmer::tool(
+    fun = function() "This is a simple text response for testing.",
+    name = "test_simple_text",
+    description = "Tests simple text content response"
+  ),
+  ellmer::tool(
+    fun = function() {
+      ellmer::ContentImageInline(
+        type = "image/png",
+        data = TEST_IMAGE_BASE64
+      )
+    },
+    name = "test_image_content",
+    description = "Tests image content response"
+  ),
+  ellmer::tool(
+    fun = function() {
+      list(
+        type = "audio",
+        data = TEST_AUDIO_BASE64,
+        mimeType = "audio/wav"
+      )
+    },
+    name = "test_audio_content",
+    description = "Tests audio content response"
+  ),
+  ellmer::tool(
+    fun = function() {
+      list(
+        type = "resource",
+        resource = list(
+          uri = "test://embedded-resource",
+          mimeType = "text/plain",
+          text = "This is an embedded resource content."
+        )
+      )
+    },
+    name = "test_embedded_resource",
+    description = "Tests embedded resource content response"
+  ),
+  ellmer::tool(
+    fun = function() {
+      list(
+        list(type = "text", text = "Multiple content types test:"),
+        list(
+          type = "image",
+          data = TEST_IMAGE_BASE64,
+          mimeType = "image/png"
+        ),
+        list(
+          type = "resource",
+          resource = list(
+            uri = "test://mixed-content-resource",
+            mimeType = "application/json",
+            text = "{\"test\":\"data\",\"value\":123}"
+          )
+        )
+      )
+    },
+    name = "test_multiple_content_types",
+    description = "Tests mixed content response"
+  ),
+  ellmer::tool(
+    fun = function() {
+      stop(
+        "This tool intentionally returns an error for testing",
+        call. = FALSE
+      )
+    },
+    name = "test_error_handling",
+    description = "Tests tool execution error response"
+  ),
+  json_schema_2020_12_tool
+)

--- a/conformance/fixtures/stateless.R
+++ b/conformance/fixtures/stateless.R
@@ -1,0 +1,67 @@
+header_echo_tool <- ellmer::tool(
+  fun = function(value) value,
+  name = "test_header_echo",
+  description = "Echoes a value supplied through an MCP parameter header",
+  arguments = list(
+    value = ellmer::type_string("The value to echo")
+  )
+)
+attr(header_echo_tool, "mcp_input_schema") <- list(
+  type = "object",
+  properties = list(
+    value = list(
+      type = "string",
+      `x-mcp-header` = "value"
+    )
+  ),
+  required = list("value")
+)
+
+mrtr_tools <- lapply(
+  c(
+    "test_input_required_result_elicitation",
+    "test_input_required_result_sampling",
+    "test_input_required_result_list_roots",
+    "test_input_required_result_request_state",
+    "test_input_required_result_multiple_inputs",
+    "test_input_required_result_multi_round",
+    "test_input_required_result_tampered_state",
+    "test_input_required_result_capabilities"
+  ),
+  function(name) {
+    ellmer::tool(
+      fun = function() "Input-required workflow completed",
+      name = name,
+      description = "Exercises a stateless multi-round-trip request"
+    )
+  }
+)
+
+c(list(
+  ellmer::tool(
+    fun = function() "Capability requirement satisfied",
+    name = "test_missing_capability",
+    description = "Requires the client sampling capability"
+  ),
+  ellmer::tool(
+    fun = function() "Streaming elicitation completed",
+    name = "test_streaming_elicitation",
+    description = "Exercises a stateless response stream"
+  ),
+  ellmer::tool(
+    fun = function() "Logging tool completed",
+    name = "test_logging_tool",
+    description = "Only logs when explicitly requested"
+  ),
+  ellmer::tool(
+    fun = function() "Tool list changed",
+    name = "test_trigger_tool_change",
+    description = "Triggers a tools list-changed notification"
+  ),
+  ellmer::tool(
+    fun = function() "Prompt list changed",
+    name = "test_trigger_prompt_change",
+    description = "Triggers a prompts list-changed notification"
+  ),
+  header_echo_tool
+), mrtr_tools)

--- a/conformance/fixtures/streaming.R
+++ b/conformance/fixtures/streaming.R
@@ -1,0 +1,48 @@
+list(
+  ellmer::tool(
+    fun = function() "Tool with logging executed successfully",
+    name = "test_tool_with_logging",
+    description = "Emits logging notifications while executing"
+  ),
+  ellmer::tool(
+    fun = function() "Progress token is supplied through MCP request metadata",
+    name = "test_tool_with_progress",
+    description = "Emits progress notifications while executing"
+  ),
+  ellmer::tool(
+    fun = function() {
+      paste(
+        "Reconnection test completed successfully.",
+        "The SSE stream remained available."
+      )
+    },
+    name = "test_reconnection",
+    description = "Tests SSE reconnection behavior"
+  ),
+  ellmer::tool(
+    fun = function(prompt) paste0("LLM response: ", prompt),
+    name = "test_sampling",
+    description = "Requests LLM sampling from the client",
+    arguments = list(
+      prompt = ellmer::type_string("The prompt to send to the LLM")
+    )
+  ),
+  ellmer::tool(
+    fun = function(message) paste0("User response: ", message),
+    name = "test_elicitation",
+    description = "Requests structured user input from the client",
+    arguments = list(
+      message = ellmer::type_string("The message to show the user")
+    )
+  ),
+  ellmer::tool(
+    fun = function() "Elicitation completed with default values",
+    name = "test_elicitation_sep1034_defaults",
+    description = "Tests elicitation default values"
+  ),
+  ellmer::tool(
+    fun = function() "Elicitation completed with enum values",
+    name = "test_elicitation_sep1330_enums",
+    description = "Tests elicitation enum schema variants"
+  )
+)

--- a/conformance/reference/FEATURE-GUIDE.md
+++ b/conformance/reference/FEATURE-GUIDE.md
@@ -1,0 +1,120 @@
+# Feature-authoring guide (conformance-first, merge-clean)
+
+This repo is a **fork-and-elevate** of Posit's `mcptools`, driven by the official
+[MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The
+goal is to take the current spec (**2025-11-25**) fully green, then add the
+**2026-07-28** GA lifecycle + cross-version support.
+
+Work happens in **parallel feature workspaces**, each branched off the
+`conformance-foundation` branch and merged back. The foundation is designed so
+that adding a feature touches **only new files**, keeping merges conflict-free.
+
+## The additive registry (why merges don't collide)
+
+The central request dispatchers in `R/server.R` are frozen. Instead of editing
+them, a feature registers handlers + capabilities through
+`R/mcp-registry.R`:
+
+- `register_mcp_method(method, handler)` — handle a JSON-RPC method.
+- `register_mcp_capability(fragment)` — merge a fragment into the advertised
+  `capabilities` map (e.g. `list(resources = named_list(subscribe = TRUE))`).
+
+All registration runs from a **registrar** you name `.register_mcp_<feature>()`.
+`.onLoad()` auto-discovers every `.register_mcp_*` in the namespace and runs it —
+so a feature is a **new file only**.
+
+### Handler contract
+
+```r
+handler <- function(data, protocol_version, transport) { ... }
+```
+
+- `data` — parsed JSON-RPC request/notification (an R list).
+- `protocol_version` — negotiated version string (e.g. `"2025-11-25"`).
+- `transport` — `"http"` or `"stdio"`.
+- Return value for a **request** (`data$id` present):
+  - a `list` → sent as the JSON-RPC `result`.
+  - `jsonrpc_error(code, message, data = NULL)` → sent as the JSON-RPC `error`.
+- Return value for a **notification** (`data$id` absent) is ignored.
+
+Useful internal helpers: `named_list()` (forces `{}` not `[]` when empty),
+`drop_nulls()`, `jsonrpc_response()`, `%||%`, and the `the` package env.
+
+## Anatomy of a feature file
+
+```r
+# R/mcp-resources.R
+.mcp_resources_list <- function(data, protocol_version, transport) {
+  list(resources = list(
+    list(uri = "file:///example.txt", name = "example", mimeType = "text/plain")
+  ))
+}
+
+.mcp_resources_read <- function(data, protocol_version, transport) {
+  uri <- data$params$uri
+  if (!identical(uri, "file:///example.txt")) {
+    return(jsonrpc_error(-32602, paste("Unknown resource:", uri)))
+  }
+  list(contents = list(
+    list(uri = uri, mimeType = "text/plain", text = "hello")
+  ))
+}
+
+# Registrar — auto-discovered by .onLoad(). MUST be named .register_mcp_<feature>.
+.register_mcp_resources <- function() {
+  register_mcp_method("resources/list", .mcp_resources_list)
+  register_mcp_method("resources/read", .mcp_resources_read)
+  register_mcp_capability(list(resources = named_list(
+    subscribe = FALSE, listChanged = FALSE
+  )))
+}
+```
+
+If your feature needs **tools** (e.g. tool content-type scenarios), add a
+fixture file under `conformance/fixtures/` (see that dir's README) instead of
+editing the launcher.
+
+## Workflow for a feature workspace
+
+1. Branch off `conformance-foundation`.
+2. Read the exact contract for your scenarios:
+   - `conformance/reference/everything-server-contract.md` — per-scenario tool
+     names, magic values, resource/prompt payloads, schemas.
+   - `conformance/reference/sep-implementation-guide.md` — SEP numbers,
+     JSON-RPC shapes, reference-SDK PRs, gotchas, dependency graph.
+3. Add `R/mcp-<feature>.R` (+ any `conformance/fixtures/*.R`).
+4. `R CMD INSTALL --no-docs --no-multiarch .`
+5. Remove the scenarios you now satisfy from
+   `conformance/expected-failures.yml`.
+6. `make conformance` — it must exit 0. The evaluator fails on **unexpected
+   passes** too, so you must delete every entry you turn green (this is the
+   ratchet).
+7. Merge back into `conformance-foundation`.
+
+## Local iteration without the full suite
+
+```r
+R CMD INSTALL --no-docs --no-multiarch .
+Rscript -e '
+  ns <- getNamespace("mcptools"); g <- function(x) get(x, ns)
+  print(g("dispatch_mcp_method")(list(method="resources/list", id=1L), "2025-11-25"))
+'
+```
+
+Or drive the live server with the official Inspector CLI:
+
+```sh
+Rscript conformance/everything-server.R &   # boots http://127.0.0.1:3001/mcp
+npx @modelcontextprotocol/inspector --cli \
+  --server-url http://127.0.0.1:3001/mcp --transport http \
+  --header "MCP-Protocol-Version: 2025-11-25" --method resources/list
+```
+
+## Gotchas
+
+- Commits in this repo are configured to sign via 1Password, which is
+  unreachable in the agent sandbox → use `git commit --no-gpg-sign`.
+- ellmer derives a tool's wire name from `fun`; pass `name =` to force it.
+- Server→client methods (elicitation, sampling, progress) require real
+  Streamable-HTTP **SSE** (GET currently returns 405). That transport work is
+  sequential and gates those features — see the SEP guide's dependency graph.

--- a/conformance/reference/everything-server-contract.md
+++ b/conformance/reference/everything-server-contract.md
@@ -1,0 +1,1206 @@
+# MCP Everything-Server Conformance Contract
+
+> **Source ground truth:** `/tmp/conformance/` (official conformance suite)  
+> **Reference implementation:** `/tmp/conformance/examples/servers/typescript/everything-server.ts`  
+> **Spec versions covered:** `2025-06-18`, `2025-11-25`, `2026-07-28` (draft)
+
+---
+
+## 1. Core / Lifecycle
+
+### 1.1 `server-initialize` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/lifecycle.ts:25-186`
+
+**Methods exercised (in order):**
+1. `POST /mcp` → `initialize` (no `MCP-Session-Id` header)
+2. `POST /mcp` → `notifications/initialized` (with `MCP-Session-Id` header)
+
+**Request shape:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {},
+    "clientInfo": { "name": "conformance-session-id-test", "version": "1.0.0" }
+  }
+}
+```
+
+**Required server response:**
+- HTTP 200 with JSON or SSE containing `result.protocolVersion`, `result.capabilities`, `result.serverInfo`
+- `MCP-Session-Id` response header (optional but if set MUST contain only visible ASCII chars `0x21–0x7E`)
+
+**Checks asserted:**
+- `server-initialize`: Connection completes (SUCCESS if no exception)
+- `server-session-id-visible-ascii`: If `MCP-Session-Id` header present, validate charset `/^[\x21-\x7E]+$/`
+
+**Required capabilities advertised in `initialize` result:**
+```json
+{
+  "tools":     { "listChanged": true },
+  "resources": { "subscribe": true, "listChanged": true },
+  "prompts":   { "listChanged": true },
+  "logging":   {},
+  "completions": {}
+}
+```
+**Source:** `everything-server.ts:209-230`
+
+---
+
+### 1.2 `ping` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/utils.ts:97-188`
+
+**Methods exercised:** `ping`
+
+**Required response:** `{}` (empty JSON object)
+
+**Check asserted:** `result` must be empty (`Object.keys(result).length === 0`)
+
+---
+
+### 1.3 `logging-set-level` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/utils.ts:13-95`
+
+**Methods exercised:** `logging/setLevel`
+
+**Request params:** `{ "level": "info" }`
+
+**Required response:** `{}` (empty object)
+
+**Log levels supported:** `debug | info | notice | warning | error | critical | alert | emergency`
+
+**Server implementation (`everything-server.ts:1089-1096`):**
+```typescript
+mcpServer.server.setRequestHandler(
+  z.object({ method: z.literal('logging/setLevel') }).passthrough(),
+  async (request: any) => {
+    const level = request.params.level;
+    sendLog('info', `Log level set to: ${level}`);
+    return {};
+  }
+);
+```
+
+---
+
+### 1.4 `completion-complete` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/utils.ts:190-303`
+
+**Methods exercised:** `completion/complete`
+
+**Request params:**
+```json
+{
+  "ref": { "type": "ref/prompt", "name": "test_prompt_with_arguments" },
+  "argument": { "name": "arg1", "value": "test" }
+}
+```
+
+**Required response shape:**
+```json
+{
+  "completion": {
+    "values": [],
+    "total": 0,
+    "hasMore": false
+  }
+}
+```
+
+**Check asserted:** `result.completion` exists and `result.completion.values` is an array (may be empty).
+
+**Server implementation (`everything-server.ts:1100-1113`):**
+```typescript
+mcpServer.server.setRequestHandler(
+  z.object({ method: z.literal('completion/complete') }).passthrough(),
+  async (_request: any) => {
+    return { completion: { values: [], total: 0, hasMore: false } };
+  }
+);
+```
+
+**Required capability:** `completions: {}` in initialize result.
+
+---
+
+## 2. Tools
+
+### Tool Name Format (SEP-986)
+
+**Source:** `src/scenarios/server/tools.ts:24-46`
+
+- Pattern: `/^[A-Za-z0-9_./-]+$/`
+- Length: 1–64 characters
+- Check ID: `tools-name-format`
+
+---
+
+### 2.1 `tools-list` (introduced `2025-06-18`)
+
+**Methods exercised:** `tools/list`
+
+**Each tool MUST have:**
+- `name` (string, 1–64 chars, `/^[A-Za-z0-9_./-]+$/`)
+- `description` (string)
+- `inputSchema` (valid JSON Schema object)
+
+**Check IDs:** `tools-list`, `tools-name-format`
+
+---
+
+### 2.2 `tools-call-simple-text` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:188-271`
+
+**Fixture:** Tool `test_simple_text`, no arguments.
+
+**Required response:**
+```json
+{
+  "content": [
+    { "type": "text", "text": "This is a simple text response for testing." }
+  ]
+}
+```
+
+**Checks:** content array non-empty, at least one `type: "text"` item with non-empty `text` field.
+
+**Server implementation (`everything-server.ts:302-314`):**
+```typescript
+mcpServer.tool('test_simple_text', 'Tests simple text content response', {}, async () => {
+  return { content: [{ type: 'text', text: 'This is a simple text response for testing.' }] };
+});
+```
+
+---
+
+### 2.3 `tools-call-image` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:273-359`
+
+**Fixture:** Tool `test_image_content`, no required arguments.
+
+**Required response:**
+```json
+{
+  "content": [
+    { "type": "image", "data": "<base64-png>", "mimeType": "image/png" }
+  ]
+}
+```
+
+**Magic value (1×1 red pixel PNG):**
+```
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==
+```
+**Source:** `everything-server.ts:159-160`
+
+**Checks:** `imageContent.data` non-empty, `imageContent.mimeType` non-empty.
+
+---
+
+### 2.4 `tools-call-audio` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:1028-1121`
+
+**Fixture:** Tool `test_audio_content`, no arguments.
+
+**Required response:**
+```json
+{
+  "content": [
+    { "type": "audio", "data": "<base64-wav>", "mimeType": "audio/wav" }
+  ]
+}
+```
+
+**Magic value (minimal WAV):**
+```
+UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQIAAAA=
+```
+**Source:** `everything-server.ts:162-164`
+
+**Checks:** mimeType MUST be exactly `"audio/wav"` (`tools.ts:1077-1079`)
+
+---
+
+### 2.5 `tools-call-embedded-resource` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:1123-1210`
+
+**Fixture:** Tool `test_embedded_resource`, no arguments.
+
+**Required response:**
+```json
+{
+  "content": [
+    {
+      "type": "resource",
+      "resource": {
+        "uri": "test://embedded-resource",
+        "mimeType": "text/plain",
+        "text": "This is an embedded resource content."
+      }
+    }
+  ]
+}
+```
+
+**Checks:** `resource.uri`, `resource.mimeType`, and either `resource.text` or `resource.blob` must be present.
+
+---
+
+### 2.6 `tools-call-mixed-content` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:361-460`
+
+**Fixture:** Tool `test_multiple_content_types`, no arguments.
+
+**Required response (all 3 content types):**
+```json
+{
+  "content": [
+    { "type": "text", "text": "Multiple content types test:" },
+    { "type": "image", "data": "<base64-png>", "mimeType": "image/png" },
+    {
+      "type": "resource",
+      "resource": {
+        "uri": "test://mixed-content-resource",
+        "mimeType": "application/json",
+        "text": "{\"test\":\"data\",\"value\":123}"
+      }
+    }
+  ]
+}
+```
+
+**Checks:** content array must have ≥2 items, must include at least one each of `type: "text"`, `type: "image"`, `type: "resource"`.
+
+---
+
+### 2.7 `tools-call-with-logging` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/tools.ts:462-553`
+
+**Fixture:** Tool `test_tool_with_logging`, no arguments.
+
+**Behavior:** During execution send exactly 3 `notifications/message` at `"info"` level:
+1. `"Tool execution started"`
+2. `"Tool processing data"` (after ~50 ms delay)
+3. `"Tool execution completed"` (after another ~50 ms delay)
+
+**Return:** `{ "content": [{ "type": "text", "text": "Tool with logging executed successfully" }] }`
+
+**Setup:** Client must call `logging/setLevel` with `"debug"` before calling tool.
+
+**Checks:** `logNotifications.length >= 3` (from `notifications/message` events).
+
+**Notification format:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/message",
+  "params": { "level": "info", "data": "Tool execution started" }
+}
+```
+**Source:** `everything-server.ts:400-432`
+
+---
+
+### 2.8 `tools-call-error` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:555-638`
+
+**Fixture:** Tool `test_error_handling`, no arguments.
+
+**Required response (NOT a JSON-RPC error — must be a successful RPC with `isError: true`):**
+```json
+{
+  "isError": true,
+  "content": [
+    { "type": "text", "text": "This tool intentionally returns an error for testing" }
+  ]
+}
+```
+
+**Important:** The SDK converts a thrown `Error` into `isError: true` automatically. The check asserts `result.isError === true` and `result.content[0].text` is truthy.
+
+**Server implementation (`everything-server.ts:483-491`):**
+```typescript
+mcpServer.registerTool('test_error_handling', { description: 'Tests error response handling' }, async () => {
+  throw new Error('This tool intentionally returns an error for testing');
+});
+```
+
+---
+
+### 2.9 `tools-call-with-progress` (introduced `2025-06-18`)
+
+**Source:** `src/scenarios/server/tools.ts:640-759`
+
+**Fixture:** Tool `test_tool_with_progress`, no required arguments.
+
+**Request shape includes `_meta.progressToken`:**
+```json
+{
+  "name": "test_tool_with_progress",
+  "arguments": {},
+  "_meta": { "progressToken": "progress-test-1" }
+}
+```
+
+**Required behavior:** Send exactly 3 `notifications/progress` in order:
+```json
+{ "method": "notifications/progress", "params": { "progressToken": "progress-test-1", "progress": 0, "total": 100, "message": "Completed step 0 of 100" } }
+{ "method": "notifications/progress", "params": { "progressToken": "progress-test-1", "progress": 50, "total": 100, "message": "Completed step 50 of 100" } }
+{ "method": "notifications/progress", "params": { "progressToken": "progress-test-1", "progress": 100, "total": 100, "message": "Completed step 100 of 100" } }
+```
+
+**Return:** `{ "content": [{ "type": "text", "text": "<progressToken value as string>" }] }`
+
+**Checks:** ≥3 progress notifications, progressToken matches `"progress-test-1"`, values non-decreasing (0 ≤ 50 ≤ 100).
+
+**Source:** `everything-server.ts:434-480`
+
+---
+
+### 2.10 `tools-call-sampling` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/tools.ts:761-891`
+
+**Fixture:** Tool `test_sampling` with argument `prompt` (string, required).
+
+**Behavior:** Server issues `sampling/createMessage` to client:
+```json
+{
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [{ "role": "user", "content": { "type": "text", "text": "<prompt arg>" } }],
+    "maxTokens": 100
+  }
+}
+```
+
+**The conformance test client responds with:**
+```json
+{ "role": "assistant", "content": { "type": "text", "text": "This is a test response from the client" }, "model": "test-model", "stopReason": "endTurn" }
+```
+
+**Server returns:** `{ "content": [{ "type": "text", "text": "LLM response: This is a test response from the client" }] }`
+
+**Checks:** `samplingRequested === true`, content array non-empty.
+
+**Source:** `everything-server.ts:533-591`
+
+---
+
+### 2.11 `tools-call-elicitation` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/tools.ts:893-1026`
+
+**Fixture:** Tool `test_elicitation` with argument `message` (string, required).
+
+**Behavior:** Server issues `elicitation/create` to client:
+```json
+{
+  "method": "elicitation/create",
+  "params": {
+    "message": "<message arg>",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "response": { "type": "string", "description": "User's response" }
+      },
+      "required": ["response"]
+    }
+  }
+}
+```
+
+> **Note:** The scenario description (line 920) shows `username` and `email` fields, but the actual server implementation (line 609-619) uses a `response` field only. The conformance client test handler accepts any schema and returns `{ action: "accept", content: { username: "testuser", email: "test@example.com" } }`.
+
+**Server returns:** `{ "content": [{ "type": "text", "text": "User response: action=accept, content={...}" }] }`
+
+**Checks:** `elicitationRequested === true`, content array non-empty.
+
+**Source:** `everything-server.ts:593-645`
+
+---
+
+### 2.12 `json-schema-2020-12` (introduced `2025-11-25`)
+
+**Source:** `src/scenarios/server/json-schema-2020-12.ts:88-352`
+
+**Fixture:** Tool `json_schema_2020_12_tool`.
+
+**The inputSchema returned by `tools/list` MUST be exactly:**
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$defs": {
+    "address": {
+      "$anchor": "addressDef",
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    }
+  },
+  "properties": {
+    "name": { "type": "string" },
+    "address": { "$ref": "#/$defs/address" },
+    "contactMethod": { "type": "string", "enum": ["phone", "email"] },
+    "phone": { "type": "string" },
+    "email": { "type": "string" }
+  },
+  "allOf": [{ "anyOf": [{ "required": ["phone"] }, { "required": ["email"] }] }],
+  "if": { "properties": { "contactMethod": { "const": "phone" } }, "required": ["contactMethod"] },
+  "then": { "required": ["phone"] },
+  "else": { "required": ["email"] },
+  "additionalProperties": false
+}
+```
+**Source:** `everything-server.ts:169-205`, `json-schema-2020-12.ts:36-64`
+
+**Checks asserted (in order):**
+1. `json-schema-2020-12-tool-found`: tool `json_schema_2020_12_tool` exists in `tools/list`
+2. `json-schema-2020-12-$schema`: `inputSchema.$schema === "https://json-schema.org/draft/2020-12/schema"` (MUST for all versions)
+3. `json-schema-2020-12-$defs`: `inputSchema.$defs.address` exists (MUST)
+4. `json-schema-2020-12-additionalProperties`: `inputSchema.additionalProperties === false` (MUST)
+5. `sep-2106-composition-keywords-preserved`: `inputSchema.allOf` with nested `anyOf` (FAILURE only on `2026-07-28`, SKIPPED on earlier)
+6. `sep-2106-conditional-keywords-preserved`: `if/then/else` present (same gating)
+7. `sep-2106-anchor-keyword-preserved`: `$defs.address.$anchor` present (same gating)
+
+**Implementation note:** The server overrides `tools/list` to return the raw JSON Schema object for this tool only; other tools use Zod-converted schemas. (`everything-server.ts:1120-1172`)
+
+---
+
+## 3. Resources
+
+### 3.1 `resources-list` (introduced `2025-06-18`)
+
+**Methods:** `resources/list`
+
+**Each resource MUST have:** `uri`, `name` (description optional but recommended).
+
+**Required resources (from `everything-server.ts:854-970`):**
+| Name | URI | mimeType |
+|------|-----|----------|
+| `static-text` | `test://static-text` | `text/plain` |
+| `static-binary` | `test://static-binary` | `image/png` |
+| `watched-resource` | `test://watched-resource` | `text/plain` |
+
+**Template:** `test://template/{id}/data` (listed via `resources/templates/list`, not `resources/list`)
+
+---
+
+### 3.2 `resources-read-text` (introduced `2025-06-18`)
+
+**Methods:** `resources/read` with `{ "uri": "test://static-text" }`
+
+**Required response:**
+```json
+{
+  "contents": [
+    {
+      "uri": "test://static-text",
+      "mimeType": "text/plain",
+      "text": "This is the content of the static text resource."
+    }
+  ]
+}
+```
+
+**Checks:** `contents[0].uri`, `contents[0].mimeType`, `contents[0].text` all non-empty.
+
+---
+
+### 3.3 `resources-read-binary` (introduced `2025-06-18`)
+
+**Methods:** `resources/read` with `{ "uri": "test://static-binary" }`
+
+**Required response:**
+```json
+{
+  "contents": [
+    {
+      "uri": "test://static-binary",
+      "mimeType": "image/png",
+      "blob": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+    }
+  ]
+}
+```
+
+**Checks:** `contents[0].blob` non-empty (binary field, not `text`).
+
+---
+
+### 3.4 `resources-templates-read` (introduced `2025-06-18`)
+
+**Methods:** `resources/read` with `{ "uri": "test://template/123/data" }`
+
+**Template:** `test://template/{id}/data` (RFC 6570 URI template)
+
+**Required response:**
+```json
+{
+  "contents": [
+    {
+      "uri": "test://template/123/data",
+      "mimeType": "application/json",
+      "text": "{\"id\":\"123\",\"templateTest\":true,\"data\":\"Data for ID: 123\"}"
+    }
+  ]
+}
+```
+
+**Check:** `contents[0].text` must include the string `"123"` (parameter substitution verified).
+
+**Server implementation (`everything-server.ts:900-927`):**
+```typescript
+mcpServer.registerResource('template', new ResourceTemplate('test://template/{id}/data', { list: undefined }), ...,
+  async (uri, variables) => {
+    const id = variables.id;
+    return { contents: [{ uri: uri.toString(), mimeType: 'application/json',
+      text: JSON.stringify({ id, templateTest: true, data: `Data for ID: ${id}` }) }] };
+  }
+);
+```
+
+---
+
+### 3.5 `resources-subscribe` (introduced `2025-06-18`, removed in draft)
+
+**Methods:** `resources/subscribe` with `{ "uri": "test://watched-resource" }`
+
+**Required response:** `{}` (empty object)
+
+**Required capability:** `resources.subscribe: true` in initialize.
+
+---
+
+### 3.6 `resources-unsubscribe` (introduced `2025-06-18`, removed in draft)
+
+**Source:** `src/scenarios/server/resources.ts:604-672`
+
+**Methods (in order):**
+1. `resources/subscribe` with `{ "uri": "test://watched-resource" }`
+2. `resources/unsubscribe` with `{ "uri": "test://watched-resource" }`
+
+**Required response for unsubscribe:** `{}` (empty object)
+
+---
+
+## 4. Prompts
+
+### 4.1 `prompts-list` (introduced `2025-06-18`)
+
+**Methods:** `prompts/list`
+
+**Each prompt MUST have:** `name`, `description`. `arguments` array is optional.
+
+**Required prompts (from `everything-server.ts:972-1085`):**
+| Name | Arguments |
+|------|-----------|
+| `test_simple_prompt` | none |
+| `test_prompt_with_arguments` | `arg1` (string), `arg2` (string) |
+| `test_prompt_with_embedded_resource` | `resourceUri` (string) |
+| `test_prompt_with_image` | none |
+
+---
+
+### 4.2 `prompts-get-simple` (introduced `2025-06-18`)
+
+**Methods:** `prompts/get` with `{ "name": "test_simple_prompt" }`
+
+**Required response:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": { "type": "text", "text": "This is a simple prompt for testing." }
+    }
+  ]
+}
+```
+
+**Checks:** messages non-empty, each message has `role` and `content`.
+
+---
+
+### 4.3 `prompts-get-with-args` (introduced `2025-06-18`)
+
+**Methods:** `prompts/get` with:
+```json
+{ "name": "test_prompt_with_arguments", "arguments": { "arg1": "testValue1", "arg2": "testValue2" } }
+```
+
+**Required response must include both argument values in message text:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": { "type": "text", "text": "Prompt with arguments: arg1='testValue1', arg2='testValue2'" }
+    }
+  ]
+}
+```
+
+**Checks:** `JSON.stringify(result.messages)` includes `"testValue1"` AND `"testValue2"`.
+
+---
+
+### 4.4 `prompts-get-embedded-resource` (introduced `2025-06-18`)
+
+**Methods:** `prompts/get` with:
+```json
+{ "name": "test_prompt_with_embedded_resource", "arguments": { "resourceUri": "test://example-resource" } }
+```
+
+**Required response:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "resource",
+        "resource": {
+          "uri": "test://example-resource",
+          "mimeType": "text/plain",
+          "text": "Embedded resource content for testing."
+        }
+      }
+    },
+    {
+      "role": "user",
+      "content": { "type": "text", "text": "Please process the embedded resource above." }
+    }
+  ]
+}
+```
+
+**Check:** At least one message with `content.type === "resource"` OR `content.resource !== undefined`.
+
+---
+
+### 4.5 `prompts-get-with-image` (introduced `2025-06-18`)
+
+**Methods:** `prompts/get` with `{ "name": "test_prompt_with_image" }`
+
+**Required response:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "image",
+        "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png"
+      }
+    },
+    {
+      "role": "user",
+      "content": { "type": "text", "text": "Please analyze the image above." }
+    }
+  ]
+}
+```
+
+**Check:** At least one message with `content.type === "image"` AND `content.data` AND `content.mimeType`.
+
+---
+
+## 5. Elicitation
+
+### 5.1 `elicitation-sep1034-defaults` (introduced `2025-11-25`, removed in draft)
+
+**Source:** `src/scenarios/server/elicitation-defaults.ts`
+
+**Fixture:** Tool `test_elicitation_sep1034_defaults`, no arguments.
+
+**Behavior:** Server sends `elicitation/create` with this EXACT schema:
+```json
+{
+  "type": "object",
+  "properties": {
+    "name":     { "type": "string",  "description": "User name",          "default": "John Doe" },
+    "age":      { "type": "integer", "description": "User age",           "default": 30 },
+    "score":    { "type": "number",  "description": "User score",         "default": 95.5 },
+    "status":   { "type": "string",  "description": "User status",        "enum": ["active","inactive","pending"], "default": "active" },
+    "verified": { "type": "boolean", "description": "Verification status","default": true }
+  },
+  "required": []
+}
+```
+
+**Message:** `"Please review and update the form fields with defaults"`
+
+**Checks (each field validated separately):**
+- `name`: `type === "string"`, `default === "John Doe"`
+- `age`: `type === "integer"`, `default === 30`
+- `score`: `type === "number"`, `default === 95.5`
+- `status`: `type === "string"`, `enum` array present, `default === "active"` (must be valid enum member)
+- `verified`: `type === "boolean"`, `default === true`
+
+**Source:** `everything-server.ts:648-719`
+
+---
+
+### 5.2 `elicitation-sep1330-enums` (introduced `2025-11-25`, removed in draft)
+
+**Source:** `src/scenarios/server/elicitation-enums.ts`
+
+**Fixture:** Tool `test_elicitation_sep1330_enums`, no arguments.
+
+**Behavior:** Server sends `elicitation/create` with schema containing all 5 enum variants:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "untitledSingle": { "type": "string", "description": "Select one option", "enum": ["option1","option2","option3"] },
+    "titledSingle":   { "type": "string", "description": "Select one option with titles", "oneOf": [
+      { "const": "value1", "title": "First Option" },
+      { "const": "value2", "title": "Second Option" },
+      { "const": "value3", "title": "Third Option" }
+    ]},
+    "legacyEnum": { "type": "string", "description": "Select one option (legacy)", "enum": ["opt1","opt2","opt3"], "enumNames": ["Option One","Option Two","Option Three"] },
+    "untitledMulti": { "type": "array", "description": "Select multiple options", "minItems": 1, "maxItems": 3,
+      "items": { "type": "string", "enum": ["option1","option2","option3"] } },
+    "titledMulti": { "type": "array", "description": "Select multiple options with titles", "minItems": 1, "maxItems": 3,
+      "items": { "anyOf": [
+        { "const": "value1", "title": "First Choice" },
+        { "const": "value2", "title": "Second Choice" },
+        { "const": "value3", "title": "Third Choice" }
+      ]}}
+  },
+  "required": []
+}
+```
+
+**Checks (one per variant):**
+- `untitledSingle`: has `enum` array, NO `oneOf`, NO `enumNames`
+- `titledSingle`: has `oneOf` with `const`/`title` pairs, NO `enum` array
+- `legacyEnum`: has both `enum` AND `enumNames` of same length
+- `untitledMulti`: `type: "array"`, `items.type: "string"`, `items.enum` array, NO `items.anyOf`
+- `titledMulti`: `type: "array"`, `items.anyOf` with `const`/`title` pairs, NO `items.enum`
+
+**Source:** `everything-server.ts:721-816`
+
+---
+
+## 6. Sampling
+
+### See `tools-call-sampling` above (section 2.10)
+
+The `test_sampling` tool must issue `sampling/createMessage` as a server→client request. The client registers a handler that returns a mock response; the server echoes it back as text content.
+
+---
+
+## 7. Progress
+
+### See `tools-call-with-progress` above (section 2.9)
+
+The `test_tool_with_progress` tool must:
+1. Read `_meta.progressToken` from the tool call request
+2. Emit 3 `notifications/progress` events on that token
+3. Return the progressToken string as text content
+
+---
+
+## 8. SSE / Transport
+
+### 8.1 `server-sse-polling` (introduced `2025-11-25`, removed in draft)
+
+**Source:** `src/scenarios/server/sse-polling.ts:74-end`
+
+**Mechanism:** Uses `test_reconnection` tool (already registered) that intentionally closes the SSE stream mid-call.
+
+**Fixture:** Tool `test_reconnection`, no arguments.
+
+**Behavior:**
+1. Client POSTs `tools/call` with `{ name: "test_reconnection" }`
+2. Server calls `transport.closeSSEStream(requestId)` to close the SSE stream mid-call
+3. Client reconnects using SSE `Last-Event-ID` (SEP-1699)
+4. Server completes the tool after 100ms and delivers result via the new SSE stream
+
+**Return:** `{ "content": [{ "type": "text", "text": "Reconnection test completed successfully. ..." }] }`
+
+**SEP-1699 requirements:**
+- SSE priming events include `event id` and may include `retry` field
+- `eventStore` must be implemented for replay
+- On GET with `Last-Event-ID`, replay missed events
+- `retryInterval: 5000` (5s) in transport config
+
+**Server implementation (`everything-server.ts:493-531, 2343-2367`):**
+```typescript
+new StreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID(),
+  eventStore: createEventStore(),  // in-memory replay store
+  retryInterval: 5000,
+  ...
+});
+```
+
+---
+
+### 8.2 `server-sse-multiple-streams` (introduced `2025-11-25`)
+
+**Source:** `src/scenarios/server/sse-multiple-streams.ts`
+
+**Mechanism:** Client sends 3 concurrent POST requests for `tools/list`, each must get its own response.
+
+**Test:**
+- 3 simultaneous POST requests with `id: 1000`, `1001`, `1002` to `/mcp`
+- All must return HTTP 200
+- Each may return JSON or SSE stream
+- Content types collected and validated
+
+**Requirements:**
+- Server MUST handle concurrent POST requests on the same session
+- Each POST request gets its own independent stream
+- Multiple SSE streams per session are allowed
+
+---
+
+## 9. DNS Rebinding Protection
+
+### 9.1 `dns-rebinding-protection` (introduced `2025-11-25`)
+
+**Source:** `src/scenarios/server/dns-rebinding.ts`
+
+**Applies to:** Localhost servers only (`localhost`, `127.0.0.1`, `[::1]`)
+
+**Test 1 - Evil host rejected:**
+```
+Host: evil.example.com
+Origin: http://evil.example.com
+```
+Must return HTTP 4xx (400–499).
+
+**Test 2 - Valid localhost accepted:**
+```
+Host: localhost:3000  (actual server host)
+Origin: http://localhost:3000
+```
+Must return HTTP 2xx (200–299).
+
+**Implementation:** Use `createMcpExpressApp()` from `@modelcontextprotocol/sdk/server/express.js` which provides built-in DNS rebinding protection. (`everything-server.ts:1185`)
+
+---
+
+## 10. Stateless Lifecycle (2026-07-28 draft spec, SEP-2575)
+
+### 10.1 Overview
+
+**Source:** `src/scenarios/server/stateless.ts`, `everything-server.ts:1228-2330`
+
+The `2026-07-28` spec replaces the stateful `initialize`/session lifecycle with per-request `_meta` and `server/discover`.
+
+### 10.2 Per-Request `_meta` Structure
+
+Every request to a stateless server MUST carry:
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientInfo": { "name": "...", "version": "..." },
+    "io.modelcontextprotocol/clientCapabilities": {}
+  }
+}
+```
+
+`clientInfo` is a SHOULD (optional); `protocolVersion` and `clientCapabilities` are MUST.
+
+**Header:** `MCP-Protocol-Version: 2026-07-28` must match `_meta.io.modelcontextprotocol/protocolVersion`.
+
+### 10.3 Error Codes for Stateless Validation Failures
+
+| Condition | HTTP | JSON-RPC code |
+|-----------|------|---------------|
+| Missing `MCP-Protocol-Version` header | 400 | `-32020` |
+| Missing `_meta` or required `_meta` fields | 400 | `-32602` |
+| Header/`_meta` version mismatch | 400 | `-32020` |
+| Unsupported protocol version | 400 | `-32022` `UnsupportedProtocolVersionError` with `data.supported: ["2026-07-28"], data.requested: <version>` |
+| Missing required client capability | 400 | `-32021` `MissingRequiredClientCapabilityError` with `data.requiredCapabilities: { "sampling": {} }` |
+| Removed methods (initialize, ping, logging/setLevel, resources/subscribe, resources/unsubscribe) | 404 | `-32601` |
+| Unknown method | 404 | `-32601` |
+
+**Source:** `everything-server.ts:1287-1330`
+
+### 10.4 `server/discover` Method
+
+Stateless servers MUST implement `server/discover`:
+```json
+{
+  "result": {
+    "resultType": "complete",
+    "supportedVersions": ["2026-07-28"],
+    "capabilities": {
+      "tools": { "listChanged": true },
+      "prompts": { "listChanged": true },
+      "resources": {}
+    },
+    "_meta": {
+      "io.modelcontextprotocol/serverInfo": {
+        "name": "everything-stateless-server",
+        "version": "1.0.0"
+      }
+    },
+    "ttlMs": 0,
+    "cacheScope": "private"
+  }
+}
+```
+**Source:** `everything-server.ts:1392-1414`
+
+### 10.5 Caching Hints (SEP-2549)
+
+Cacheable stateless methods MUST include `ttlMs` and `cacheScope` in result:
+
+| Method | `ttlMs` | `cacheScope` |
+|--------|---------|--------------|
+| `server/discover` | 0 | `"private"` |
+| `tools/list` | 300000 | `"public"` |
+| `prompts/list` | 300000 | `"public"` |
+| `resources/list` | 300000 | `"public"` |
+| `resources/templates/list` | 300000 | `"public"` |
+| `resources/read` | 300000 | `"private"` |
+
+**Source:** `everything-server.ts:1239-1265`
+
+All stateless results also carry `resultType: "complete"` (stamped automatically).
+
+### 10.6 `subscriptions/listen` Stream
+
+Stateless servers MUST implement a long-lived chunked-transfer stream:
+1. First frame MUST be `notifications/subscriptions/acknowledged` with `_meta.io.modelcontextprotocol/subscriptionId`
+2. Subsequent frames deliver `notifications/tools/list_changed` or `notifications/prompts/list_changed` (matching client filter)
+3. Frames are newline-delimited JSON (not SSE)
+
+**Ack frame:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/subscriptions/acknowledged",
+  "params": {
+    "_meta": { "io.modelcontextprotocol/subscriptionId": "<request-id-as-string>" },
+    "notifications": { "toolsListChanged": true }
+  }
+}
+```
+**Source:** `everything-server.ts:1361-1389`
+
+### 10.7 `tools/call` on Stateless Path
+
+On the stateless path, `tools/call` is answered as `text/event-stream` (SSE):
+```
+Content-Type: text/event-stream
+Transfer-Encoding: chunked
+
+event: message
+data: {"jsonrpc":"2.0","method":"notifications/progress",...}
+
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{...}}
+```
+**Source:** `everything-server.ts:2246-2272`
+
+### 10.8 SDK Stateless Toggle
+
+| SDK | Stateless enable |
+|-----|-----------------|
+| `go-sdk` | `-stateless=false` default; `2026-07-28` drops flag (defaults stateless) |
+| `rust-sdk` | `STATELESS=1` env var |
+| `csharp-sdk` | Different URL: `/stateless` endpoint |
+| `python-sdk` | No toggle; same binary for both (2026-07-28 uses different baseline) |
+| `typescript-sdk` | Handled in same server at POST `/mcp`; detects missing `MCP-Session-Id` + draft version |
+
+**Source:** `src/sdk-runner/known-sdks.ts:46-154`
+
+---
+
+## 11. Magic Values Summary
+
+| Constant | Value | Source |
+|----------|-------|--------|
+| `TEST_IMAGE_BASE64` | `iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==` | `everything-server.ts:159-160` |
+| `TEST_AUDIO_BASE64` | `UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQIAAAA=` | `everything-server.ts:162-164` |
+| Simple text response | `"This is a simple text response for testing."` | `everything-server.ts:310` |
+| Static text resource content | `"This is the content of the static text resource."` | `everything-server.ts:869` |
+| Watched resource content | `"Watched resource content"` | `everything-server.ts:43` |
+| Embedded resource text | `"This is an embedded resource content."` | `everything-server.ts:360` |
+| Embedded resource URI | `"test://embedded-resource"` | `everything-server.ts:358` |
+| Mixed content resource URI | `"test://mixed-content-resource"` | `everything-server.ts:384` |
+| Mixed content resource text | `'{"test":"data","value":123}'` (JSON stringified) | `everything-server.ts:385` |
+| Simple prompt text | `"This is a simple prompt for testing."` | `everything-server.ts:987` |
+| Prompt with args text | `"Prompt with arguments: arg1='${arg1}', arg2='${arg2}'"` | `everything-server.ts:1015` |
+| Embedded resource prompt text | `"Embedded resource content for testing."` | `everything-server.ts:1043` |
+| Progress tool: return text | `String(progressToken)` (the token echoed back) | `everything-server.ts:477` |
+| Error tool message | `"This tool intentionally returns an error for testing"` | `everything-server.ts:489` |
+| Reconnection tool response | `"Reconnection test completed successfully. ..."` | `everything-server.ts:523-528` |
+
+---
+
+## 12. Complete Tool Registry
+
+| Tool Name | Arguments | Return Type | Scenario |
+|-----------|-----------|-------------|----------|
+| `test_simple_text` | none | text | `tools-call-simple-text` |
+| `test_image_content` | none | image/png | `tools-call-image` |
+| `test_audio_content` | none | audio/wav | `tools-call-audio` |
+| `test_embedded_resource` | none | resource | `tools-call-embedded-resource` |
+| `test_multiple_content_types` | none | text+image+resource | `tools-call-mixed-content` |
+| `test_tool_with_logging` | none (empty schema) | text + 3 log notifications | `tools-call-with-logging` |
+| `test_tool_with_progress` | none (empty schema) | text + 3 progress notifications | `tools-call-with-progress` |
+| `test_error_handling` | none | isError:true + text | `tools-call-error` |
+| `test_reconnection` | none (empty schema) | text (after SSE reconnect) | `server-sse-polling` |
+| `test_sampling` | `prompt` (string) | text (after sampling) | `tools-call-sampling` |
+| `test_elicitation` | `message` (string) | text (after elicitation) | `tools-call-elicitation` |
+| `test_elicitation_sep1034_defaults` | none (empty schema) | text | `elicitation-sep1034-defaults` |
+| `test_elicitation_sep1330_enums` | none (empty schema) | text | `elicitation-sep1330-enums` |
+| `json_schema_2020_12_tool` | see schema above | text | `json-schema-2020-12` |
+
+---
+
+## 13. Complete Resource Registry
+
+| Resource Name | URI | MIME | Content |
+|---------------|-----|------|---------|
+| `static-text` | `test://static-text` | `text/plain` | `"This is the content of the static text resource."` |
+| `static-binary` | `test://static-binary` | `image/png` | TEST_IMAGE_BASE64 (blob) |
+| `watched-resource` | `test://watched-resource` | `text/plain` | `"Watched resource content"` |
+| Template | `test://template/{id}/data` | `application/json` | `{"id":"<id>","templateTest":true,"data":"Data for ID: <id>"}` |
+
+---
+
+## 14. Complete Prompt Registry
+
+| Prompt Name | Arguments | Response Shape |
+|-------------|-----------|----------------|
+| `test_simple_prompt` | none | 1 message: user/text |
+| `test_prompt_with_arguments` | `arg1`, `arg2` (strings) | 1 message: user/text with args interpolated |
+| `test_prompt_with_embedded_resource` | `resourceUri` (string) | 2 messages: user/resource, user/text |
+| `test_prompt_with_image` | none | 2 messages: user/image, user/text |
+
+---
+
+## 15. Transport Requirements
+
+### Stateful (2025-06-18 / 2025-11-25)
+
+**Endpoint:** `POST /mcp`
+
+**Session lifecycle:**
+1. `POST /mcp` → `initialize` → responds with `MCP-Session-Id` header (visible ASCII only)
+2. `POST /mcp` + `MCP-Session-Id` → `notifications/initialized` → `{}` (2xx)
+3. Subsequent requests carry `MCP-Session-Id` + `MCP-Protocol-Version` headers
+4. `GET /mcp` + `MCP-Session-Id` → SSE stream for server-push
+5. `DELETE /mcp` + `MCP-Session-Id` → terminates session (returns 2xx or 405)
+6. After DELETE: requests with that session ID must return HTTP 404
+
+**Unknown session ID:** HTTP 404 `{"code": -32001, "message": "Session not found"}`
+
+**No session on non-initialize request:** HTTP 400 `{"code": -32000, "message": "Invalid or missing session ID"}`
+
+**SSE stream format (GET):** `text/event-stream`, standard SSE with `event:`, `data:`, `id:`, `retry:` fields.
+
+**SSE stream format (POST response):** `text/event-stream` or `application/json`
+
+### Stateless (2026-07-28)
+
+**Endpoint:** `POST /mcp` (same endpoint, distinguished by absence of `MCP-Session-Id`)
+
+**Per-request headers:**
+```
+MCP-Protocol-Version: 2026-07-28
+Content-Type: application/json
+Accept: application/json, text/event-stream
+```
+
+**Response:** JSON or SSE depending on method (tools/call → SSE; others → JSON)
+
+**CORS:** Expose `Mcp-Session-Id` header, allow `Content-Type`, `mcp-session-id`, `last-event-id` headers.
+
+---
+
+## 16. Scenario Version Gating
+
+| Scenario | Introduced | Removed In |
+|----------|-----------|-----------|
+| `server-initialize` | `2025-06-18` | `2026-07-28` |
+| `logging-set-level` | `2025-06-18` | `2026-07-28` |
+| `ping` | `2025-06-18` | `2026-07-28` |
+| `tools-call-simple-text` | `2025-06-18` | — |
+| `tools-call-image` | `2025-06-18` | — |
+| `tools-call-audio` | `2025-06-18` | — |
+| `tools-call-embedded-resource` | `2025-06-18` | — |
+| `tools-call-mixed-content` | `2025-06-18` | — |
+| `tools-call-with-logging` | `2025-06-18` | `2026-07-28` |
+| `tools-call-error` | `2025-06-18` | — |
+| `tools-call-with-progress` | `2025-06-18` | — |
+| `tools-call-sampling` | `2025-06-18` | `2026-07-28` |
+| `tools-call-elicitation` | `2025-06-18` | `2026-07-28` |
+| `json-schema-2020-12` | `2025-11-25` | — |
+| `elicitation-sep1034-defaults` | `2025-11-25` | `2026-07-28` |
+| `elicitation-sep1330-enums` | `2025-11-25` | `2026-07-28` |
+| `server-sse-polling` | `2025-11-25` | `2026-07-28` |
+| `server-sse-multiple-streams` | `2025-11-25` | — |
+| `resources-list` | `2025-06-18` | — |
+| `resources-read-text` | `2025-06-18` | — |
+| `resources-read-binary` | `2025-06-18` | — |
+| `resources-templates-read` | `2025-06-18` | — |
+| `resources-subscribe` | `2025-06-18` | `2026-07-28` |
+| `resources-unsubscribe` | `2025-06-18` | `2026-07-28` |
+| `prompts-list` | `2025-06-18` | — |
+| `prompts-get-simple` | `2025-06-18` | — |
+| `prompts-get-with-args` | `2025-06-18` | — |
+| `prompts-get-embedded-resource` | `2025-06-18` | — |
+| `prompts-get-with-image` | `2025-06-18` | — |
+| `completion-complete` | `2025-06-18` | — |
+| `dns-rebinding-protection` | `2025-11-25` | — |
+
+**DRAFT_PROTOCOL_VERSION constant = `"2026-07-28"`** (`src/types.ts:50`)
+
+---
+
+## Summary of Biggest Implementation Requirements
+
+Here are the critical implementation requirements for the R SDK everything-server:
+
+1. **14 tools must be registered** with exact names, exact return values including magic strings and base64 blobs. The `test_audio_content` tool's `mimeType` is checked to be exactly `"audio/wav"`. The `test_tool_with_progress` must echo back the progressToken as its text content.
+
+2. **Tool error semantics**: `test_error_handling` must throw an exception (SDK converts to `isError: true` in result, NOT a JSON-RPC error response). The check is `result.isError === true`.
+
+3. **JSON Schema 2020-12 fidelity**: `json_schema_2020_12_tool` must return the exact raw schema (with `$schema`, `$defs`, `additionalProperties`, `allOf`, `if/then/else`) — the SDK must NOT strip these fields during `tools/list`.
+
+4. **4 resources + 1 template**: with exact URIs and exact text/blob content values. The template must perform `{id}` substitution and the content must contain the substituted value (checked by string inclusion).
+
+5. **Elicitation schemas must be byte-exact**: The `sep1034-defaults` schema requires exact `default` values per field type. The `sep1330-enums` schema requires 5 specific enum variants using different structures (plain `enum`, `oneOf`, `enumNames`, `items.enum`, `items.anyOf`).
+
+6. **SSE polling/reconnection**: Requires an in-memory event store, `retryInterval: 5000`, and the `test_reconnection` tool that actively closes the SSE stream mid-call.
+
+7. **DNS rebinding**: Must use a framework that validates `Host`/`Origin` headers on localhost, rejecting non-localhost origins with 4xx.
+
+8. **Stateless (2026-07-28) is a completely different path**: No `initialize`, per-request `_meta`, `server/discover`, `subscriptions/listen` stream, caching hints on all list/read results, `tools/call` as SSE, and removed-method returns `404 + -32601`.
+
+9. **Session lifecycle**: `DELETE /mcp` with `MCP-Session-Id` must be handled; subsequent requests with that session ID must return `404`.
+
+10. **Logging**: 3 `notifications/message` events at `info` level during `test_tool_with_logging` execution, with `data` fields containing exact strings.
+
+---

--- a/conformance/reference/sep-implementation-guide.md
+++ b/conformance/reference/sep-implementation-guide.md
@@ -1,0 +1,1215 @@
+# MCP Server SEP Implementation Guide
+
+> Research date: 2026-08-01  
+> Protocol versions covered: **2025-11-25** (current GA), **2026-07-28** (new GA — "stateless lifecycle")  
+> Schema sources: `modelcontextprotocol/modelcontextprotocol` schema/2025-11-25/schema.ts and schema/2026-07-28/schema.ts  
+> Conformance source: `modelcontextprotocol/conformance` src/scenarios/
+
+---
+
+## 1. Resources
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| No dedicated SEP — core spec since inception | `resources/list`, `resources/read`, `resources/templates/list` |
+| SEP-2164 (draft/2026-07-28) | Resource-not-found error semantics: return -32602, not empty `contents[]` |
+| SEP-2575 (2026-07-28) | `subscriptions/listen` replaces `resources/subscribe` / `resources/unsubscribe` |
+| SEP-2549 (2025-11-25) | Caching: `ttlMs` + `cacheScope` on list results |
+
+### JSON-RPC Shapes (2025-11-25)
+
+```json
+// resources/list request (paginated)
+{ "jsonrpc":"2.0","id":1,"method":"resources/list","params":{"cursor":"opaque-token"} }
+
+// resources/list result
+{
+  "resources": [
+    { "uri":"test://static-text","name":"Example","description":"...","mimeType":"text/plain","size":42 }
+  ],
+  "nextCursor": "next-page-token"   // absent = last page
+}
+
+// resources/templates/list result
+{ "resourceTemplates": [{ "uriTemplate":"test://template/{id}/data","name":"...","mimeType":"application/json" }], "nextCursor": null }
+
+// resources/read request
+{ "jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"test://static-text"} }
+
+// resources/read result — TEXT
+{ "contents": [{ "uri":"test://static-text","mimeType":"text/plain","text":"This is the content." }] }
+
+// resources/read result — BINARY (base64 blob)
+{ "contents": [{ "uri":"test://static-binary","mimeType":"image/png","blob":"iVBORw0KGgo..." }] }
+
+// resources/subscribe (2025-11-25 only)
+{ "jsonrpc":"2.0","id":3,"method":"resources/subscribe","params":{"uri":"test://watched"} }
+// result: {}
+
+// resources/unsubscribe (2025-11-25 only)
+{ "jsonrpc":"2.0","id":4,"method":"resources/unsubscribe","params":{"uri":"test://watched"} }
+// result: {}
+
+// notifications/resources/updated (server → client)
+{ "jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"test://watched"} }
+
+// notifications/resources/list_changed (server → client)
+{ "jsonrpc":"2.0","method":"notifications/resources/list_changed","params":{} }
+```
+
+### 2026-07-28 Changes
+- `resources/subscribe` / `resources/unsubscribe` **removed** → use `subscriptions/listen` with `notifications.resourceSubscriptions: ["uri1","uri2"]`
+- `notifications/resources/list_changed` only arrives on a `subscriptions/listen` stream when client sets `resourcesListChanged: true`
+- `ReadResourceResult` extends `CacheableResult` → must include `ttlMs` (number, ≥0) and `cacheScope` ("public"|"private")
+- `ListResourcesResult` extends `PaginatedResult, CacheableResult` — same `ttlMs`/`cacheScope` requirement
+- `ReadResourceRequestParams` extends `InputResponseRequestParams` — can carry `inputResponses`/`requestState` for MRTR
+
+### Capability Advertisement
+```json
+// Server capabilities for resources (in initialize result / server/discover)
+"resources": {
+  "subscribe": true,        // supports resources/subscribe (2025-11-25 only)
+  "listChanged": true       // supports notifications/resources/list_changed
+}
+```
+- Must declare `subscribe: true` before client can send `resources/subscribe`
+- Must declare `listChanged: true` to emit `notifications/resources/list_changed`
+
+### Conformance Test Scenarios
+| Scenario | Spec Version | Description |
+|----------|-------------|-------------|
+| `resources-list` | 2025-06-18+ | Lists resources; validates uri+name present on each |
+| `resources-read-text` | 2025-06-18+ | Reads `test://static-text`, validates text field |
+| `resources-read-binary` | 2025-06-18+ | Reads `test://static-binary`, validates blob field |
+| `resources-templates-read` | 2025-06-18+ | Reads `test://template/123/data`, validates `{id}` substitution |
+| `resources-subscribe` | 2025-06-18+, **removed in 2026-07-28** | Subscribe returns `{}` |
+| `resources-unsubscribe` | 2025-06-18+, **removed in 2026-07-28** | Unsubscribe returns `{}` |
+| `sep-2164-resource-not-found` | 2026-07-28+ (draft) | Missing URI → -32602 with `data.uri` |
+
+Source: `modelcontextprotocol/conformance:src/scenarios/server/resources.ts`
+
+### Gotchas / Advice
+- **Binary blob must be base64-encoded** — the `blob` field is `@format byte`. Use standard base64, not URL-safe.
+- **`uri` field in `contents` must match the requested URI** (or the sub-resource URI if server splits content).
+- **Pagination cursor is opaque** — clients treat it as a black box. Servers must not reveal encoding. An absent `nextCursor` means the end of the list.
+- **Error for not-found (SEP-2164)**: Return `-32602 InvalidParams` with `data: { uri: "<requested-uri>" }`. Do NOT return a result with empty `contents: []` — that is ambiguous.
+- **`resources/subscribe` advertised separately from `listChanged`** — a server CAN support `subscribe` without supporting list change notifications, and vice versa.
+- **2026-07-28 migration**: `resources/subscribe` is gone. Use `subscriptions/listen` with `SubscriptionFilter.resourceSubscriptions`. Clients receive `notifications/subscriptions/acknowledged` first, then updates.
+- **Resource URI can use any scheme** — `test://`, `file://`, `https://`, custom schemes all allowed.
+
+---
+
+## 2. Prompts
+
+### Governing SEPs
+No dedicated SEP — core spec since inception. Conformance scenarios cover all variants.
+
+### JSON-RPC Shapes (2025-11-25 and 2026-07-28 — unchanged)
+
+```json
+// prompts/list request (paginated)
+{ "jsonrpc":"2.0","id":1,"method":"prompts/list","params":{} }
+
+// prompts/list result
+{
+  "prompts": [
+    { "name":"code-review","title":"Code Review","description":"Review code","arguments":[{"name":"code","description":"The code","required":true}] }
+  ],
+  "nextCursor": null
+}
+
+// prompts/get request
+{ "jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"code-review","arguments":{"code":"fn main() {}"}} }
+
+// prompts/get result — simple text
+{
+  "description": "A code review prompt",
+  "messages": [
+    { "role":"user","content":{"type":"text","text":"Review this code: fn main() {}"} }
+  ]
+}
+
+// prompts/get result — with image
+{
+  "messages": [
+    { "role":"user","content":{"type":"image","data":"<base64>","mimeType":"image/png"} }
+  ]
+}
+
+// prompts/get result — with embedded resource
+{
+  "messages": [
+    { "role":"user","content":{"type":"resource","resource":{"uri":"file:///readme.md","mimeType":"text/plain","text":"# README"}} }
+  ]
+}
+
+// notifications/prompts/list_changed
+{ "jsonrpc":"2.0","method":"notifications/prompts/list_changed","params":{} }
+```
+
+### Capability Advertisement
+```json
+"prompts": { "listChanged": true }
+```
+
+### 2026-07-28 Changes
+- `GetPromptRequestParams` extends `InputResponseRequestParams` — supports MRTR
+- `GetPromptResultResponse` can return `GetPromptResult | InputRequiredResult`
+- `ListPromptsResult` extends `CacheableResult` — add `ttlMs` + `cacheScope`
+- `notifications/prompts/list_changed` only on `subscriptions/listen` with `promptsListChanged: true`
+
+### Conformance Test Scenarios
+| Scenario | Description |
+|----------|-------------|
+| `prompts-list` | Lists prompts; validates name present |
+| `prompts-get-simple` | Gets prompt without args |
+| `prompts-get-with-args` | Gets prompt with arguments substituted |
+| `prompts-get-embedded-resource` | Gets prompt with embedded resource content |
+| `prompts-get-with-image` | Gets prompt with image content block |
+
+Source: `modelcontextprotocol/conformance:src/scenarios/server/prompts.ts`
+
+### Gotchas / Advice
+- **`PromptArgument.name` is the identifier** — used as the key in `arguments: { [name]: value }`.
+- **Required vs optional arguments**: `required?: boolean` defaults to false. Servers should validate required args and return -32602 if missing.
+- **`ContentBlock` in `PromptMessage`** is `TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource` — the full union. A prompt message can embed any content type.
+- **`EmbeddedResource.type` is `"resource"`** (not `"resource_link"`). `ResourceLink.type` is `"resource_link"`.
+- **Image content**: `data` field is base64-encoded, `mimeType` required.
+- **`notifications/prompts/list_changed` can fire without prior subscription** in 2025-11-25 — server may issue proactively; client should handle gracefully.
+- **Pagination**: Same cursor semantics as resources.
+
+---
+
+## 3. Completion
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-1613 | JSON Schema 2020-12 support for tool schemas |
+| SEP-2106 | JSON Schema network `$ref` dereferencing |
+
+No dedicated SEP for completion itself — core spec.
+
+### JSON-RPC Shapes (unchanged 2025-11-25 → 2026-07-28)
+
+```json
+// completion/complete request — prompt argument
+{
+  "jsonrpc":"2.0","id":1,"method":"completion/complete",
+  "params":{
+    "ref":{"type":"ref/prompt","name":"code-review"},
+    "argument":{"name":"language","value":"py"},
+    "context":{"arguments":{"style":"verbose"}}
+  }
+}
+
+// completion/complete request — resource template argument
+{
+  "jsonrpc":"2.0","id":1,"method":"completion/complete",
+  "params":{
+    "ref":{"type":"ref/resource","uri":"test://template/{language}/data"},
+    "argument":{"name":"language","value":"py"}
+  }
+}
+
+// completion/complete result
+{
+  "completion":{
+    "values":["python","pypy"],
+    "total":2,
+    "hasMore":false
+  }
+}
+```
+
+### Capability Advertisement
+```json
+"completions": {}
+```
+Must be declared; client should not call `completion/complete` if absent.
+
+### Gotchas / Advice
+- **`ref` type determines scope**: `ref/prompt` → completions for prompt arguments; `ref/resource` → completions for URI template variables.
+- **`context.arguments`** carries already-resolved variables for multi-argument templates — use this for dependent completions.
+- **`values` max 100 items** — schema enforces `@maxItems 100`. Return `hasMore: true` if more exist.
+- **`total` is optional** — use only if you know the exact count.
+- **Server must declare `completions: {}` capability** — otherwise Method Not Found (-32601) is appropriate response.
+- **`PromptReference.name`** is the prompt name (same as in prompts/list); `ResourceTemplateReference.uri` is the URI template string.
+
+---
+
+## 4. Logging
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-2577 (2026-07-28) | Logging deprecated: replaces `logging/setLevel` RPC with per-request `_meta["io.modelcontextprotocol/logLevel"]` |
+
+### JSON-RPC Shapes (2025-11-25)
+
+```json
+// Client request to set log level
+{ "jsonrpc":"2.0","id":1,"method":"logging/setLevel","params":{"level":"debug"} }
+// Result: {}
+
+// Server notification (log message)
+{
+  "jsonrpc":"2.0","method":"notifications/message",
+  "params":{ "level":"error","logger":"mymodule","data":"Connection failed: timeout" }
+}
+```
+
+**LoggingLevel values** (syslog RFC-5424 order, least to most severe):
+`"debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency"`
+
+Server sends all logs at the set level AND MORE SEVERE.
+
+### Capability Advertisement
+```json
+"logging": {}    // 2025-11-25: server declares it supports logging
+```
+
+### 2026-07-28 Changes (SEP-2577 — DEPRECATED)
+- `logging/setLevel` RPC **removed** — server MUST NOT accept it
+- `logging` capability **deprecated**
+- Client opts in per-request: `_meta["io.modelcontextprotocol/logLevel"]` = level string
+- If absent from `_meta`, server MUST NOT send any `notifications/message` for that request
+- `notifications/message` + `LoggingMessageNotification` remain in schema for 12+ months (backwards compat)
+
+### Gotchas / Advice
+- **2025-11-25**: Server MAY send logs even without `logging/setLevel` if it has its own defaults. The spec says "If no logging/setLevel request has been sent... the server MAY decide which messages to send automatically."
+- **2026-07-28**: Per-request opt-in means each POST independently sets log level via `_meta`. Servers must not carry level across requests.
+- **`data` field is `unknown`** — can be any JSON-serializable value (string, object, etc.). Not just a string.
+- **`logger` field is optional** — identifies the source module.
+- **Conformance test** (`logging-set-level`) validates that after `setLevel("debug")`, the server emits log notifications during a tool call (`tools-call-with-logging` scenario uses `test_logging` tool).
+- **Build for 2025-11-25 first** — implement `logging/setLevel` + `notifications/message`. For 2026-07-28, suppress all if `_meta` has no `logLevel`.
+
+---
+
+## 5. Elicitation
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-1034 | Default values in elicitation schemas (string, number, integer, boolean, enum) |
+| SEP-1330 | Enum schema improvements: untitled/titled single-select, untitled/titled multi-select, legacy `enumNames` |
+| SEP-2322 | Multi-round-trip (MRTR) `InputRequiredResult` — replaces direct server-to-client in 2026-07-28 |
+
+### JSON-RPC Shapes (2025-11-25 — direct server-to-client request)
+
+```json
+// Server sends elicitation/create to client (during tools/call SSE stream)
+{
+  "jsonrpc":"2.0","id":99,"method":"elicitation/create",
+  "params":{
+    "mode":"form",
+    "message":"Please provide your details",
+    "requestedSchema":{
+      "type":"object",
+      "properties":{
+        "name":{"type":"string","title":"Name","default":"John Doe"},
+        "age":{"type":"integer","title":"Age","default":30},
+        "score":{"type":"number","default":95.5},
+        "verified":{"type":"boolean","default":true},
+        "status":{"type":"string","enum":["active","inactive","pending"],"default":"active"}
+      },
+      "required":["name"]
+    }
+  }
+}
+
+// Client response
+{
+  "jsonrpc":"2.0","id":99,
+  "result":{
+    "action":"accept",
+    "content":{"name":"Jane Smith","age":25,"score":88.0,"verified":false,"status":"inactive"}
+  }
+}
+
+// OR: user declined
+{ "jsonrpc":"2.0","id":99,"result":{"action":"decline"} }
+
+// OR: user cancelled
+{ "jsonrpc":"2.0","id":99,"result":{"action":"cancel"} }
+```
+
+### SEP-1330 Enum Schema Variants
+
+```json
+// 1. Untitled single-select (simple enum array)
+{ "type":"string","enum":["option1","option2","option3"] }
+
+// 2. Titled single-select (oneOf with const/title pairs)
+{ "type":"string","oneOf":[{"const":"value1","title":"First Option"},{"const":"value2","title":"Second Option"}] }
+
+// 3. Legacy titled (DEPRECATED — use oneOf instead)
+{ "type":"string","enum":["opt1","opt2","opt3"],"enumNames":["Option One","Option Two","Option Three"] }
+
+// 4. Untitled multi-select (array with items.enum)
+{ "type":"array","items":{"type":"string","enum":["option1","option2","option3"]},"minItems":1,"maxItems":3 }
+
+// 5. Titled multi-select (array with items.anyOf const/title)
+{ "type":"array","items":{"anyOf":[{"const":"value1","title":"First Choice"},{"const":"value2","title":"Second Choice"}]} }
+```
+
+### SEP-1034 Default Values
+All primitive schema types support `default`:
+- `StringSchema.default?: string`
+- `NumberSchema.default?: number` (works for both `"number"` and `"integer"` type)
+- `BooleanSchema.default?: boolean`
+- `UntitledSingleSelectEnumSchema.default?: string` (must be in `enum` array)
+- `TitledSingleSelectEnumSchema.default?: string`
+
+### URL Elicitation Mode (2025-11-25)
+```json
+{
+  "mode":"url",
+  "message":"Complete OAuth flow",
+  "url":"https://auth.example.com/oauth?redirect=..."
+}
+// Result: { "action": "accept" }  (no content for URL mode)
+
+// Error if client doesn't support URL mode (-32042 in 2025-11-25):
+{ "error":{"code":-32042,"data":{"elicitations":[...]}} }
+```
+
+### 2026-07-28 Changes (MRTR / InputRequiredResult — SEP-2322)
+In 2026-07-28, servers return `InputRequiredResult` INSTEAD of making a separate JSON-RPC request:
+
+```json
+// tools/call result → server needs elicitation (instead of calling client):
+{
+  "resultType":"input_required",
+  "inputRequests":{
+    "userForm": {
+      "method":"elicitation/create",
+      "params":{"mode":"form","message":"Enter details","requestedSchema":{...}}
+    }
+  },
+  "requestState":"<opaque-blob-for-server>"
+}
+
+// Client retries the original tools/call with responses:
+{
+  "method":"tools/call",
+  "params":{
+    "name":"the_tool","arguments":{},
+    "inputResponses":{"userForm":{"action":"accept","content":{...}}},
+    "requestState":"<opaque-blob-from-server>"
+  }
+}
+
+// Final result:
+{ "resultType":"complete","content":[{"type":"text","text":"Done"}] }
+```
+
+### Capability Advertisement
+```json
+// Client must declare elicitation capability
+"elicitation": {
+  "form": {},    // supports form mode
+  "url": {}      // supports URL mode (optional)
+}
+```
+- Server must check client capabilities BEFORE sending elicitation
+- In 2025-11-25: If no `elicitation` capability, return -32602 or -32021
+- In 2026-07-28: Use `MissingRequiredClientCapabilityError` (-32021) with `data.requiredCapabilities`
+
+### Conformance Test Scenarios
+| Scenario | SEP | Checks |
+|----------|-----|--------|
+| `tools-call-elicitation` | — | Basic elicitation during tool call |
+| `elicitation-sep1034-defaults` | SEP-1034 | 5 checks: string/integer/number/enum/boolean defaults all present and correct |
+| `elicitation-sep1330-enums` | SEP-1330 | 5 checks: all 5 enum variants present and correctly structured |
+| `elicitation-sep1034-client-defaults` | SEP-1034 | Client side: honor defaults |
+
+**Required tool names for conformance:**
+- `test_elicitation_sep1034_defaults` — must trigger elicitation with the exact 5-field schema
+- `test_elicitation_sep1330_enums` — must trigger elicitation with all 5 enum variants
+
+Source: `modelcontextprotocol/conformance:src/scenarios/server/elicitation-defaults.ts`, `elicitation-enums.ts`
+
+### Gotchas / Advice
+- **Elicitation is FLAT** — `requestedSchema.properties` allows only `PrimitiveSchemaDefinition` (string/number/integer/boolean/enum). No nested objects or arrays (except enum arrays).
+- **Default validation for enum**: The `default` value MUST be a member of the `enum` array.
+- **`enumNames` is deprecated** — new code should use `oneOf` with `const/title` instead.
+- **Titled multi-select uses `items.anyOf`** — NOT `items.oneOf`. This is a spec-specific pattern.
+- **Client must validate `inputResponses` at runtime** — do not trust generic TypeScript generics for schema validation. The MRTR example bug (typescript-sdk#2542) shows how unchecked responses can lead to security issues.
+- **`action: "cancel"` vs `"decline"`**: "cancel" = user dismissed without choice; "decline" = explicit refusal. Server should handle all three.
+- **Scenarios `elicitation-sep1034-defaults` and `elicitation-sep1330-enums` are marked `removedIn: DRAFT_PROTOCOL_VERSION`** — these only apply to 2025-11-25. For 2026-07-28, elicitation uses MRTR.
+- **`requestState` is opaque** — clients must not interpret it, just echo it back verbatim on retry.
+
+---
+
+## 6. Sampling
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-2596 | Deprecate `includeContext` values `"thisServer"` / `"allServers"` |
+| SEP-2577 (2026-07-28) | Entire `sampling/createMessage` deprecated — use MRTR `InputRequiredResult` |
+
+### JSON-RPC Shapes (2025-11-25 — direct server-to-client request)
+
+```json
+// Server sends sampling/createMessage to client (during SSE stream)
+{
+  "jsonrpc":"2.0","id":100,"method":"sampling/createMessage",
+  "params":{
+    "messages":[{"role":"user","content":{"type":"text","text":"What is 2+2?"}}],
+    "maxTokens":100,
+    "modelPreferences":{
+      "hints":[{"name":"claude-3-5-sonnet"}],
+      "intelligencePriority":0.8,
+      "speedPriority":0.2
+    },
+    "systemPrompt":"You are a helpful assistant.",
+    "includeContext":"none"
+  }
+}
+
+// Client response
+{
+  "jsonrpc":"2.0","id":100,
+  "result":{
+    "role":"assistant",
+    "content":{"type":"text","text":"4"},
+    "model":"claude-3-5-sonnet-20241022",
+    "stopReason":"endTurn"
+  }
+}
+```
+
+### Sampling with Tools (2025-11-25+)
+```json
+// Request with tools
+{
+  "messages":[...],
+  "maxTokens":1000,
+  "tools":[{"name":"get_weather","description":"...","inputSchema":{"type":"object","properties":{"city":{"type":"string"}}}}],
+  "toolChoice":{"mode":"auto"}
+}
+
+// Client returns tool use
+{ "role":"assistant","content":{"type":"tool_use","id":"tu_1","name":"get_weather","input":{"city":"London"}} }
+
+// Client then returns final answer after providing tool result in follow-up
+{ "role":"assistant","content":{"type":"text","text":"It's 15°C in London"},"stopReason":"endTurn" }
+```
+
+### ModelPreferences
+```typescript
+interface ModelPreferences {
+  hints?: ModelHint[];          // model name substrings, in priority order
+  costPriority?: number;        // 0=unimportant, 1=most important
+  speedPriority?: number;       // 0=unimportant, 1=most important
+  intelligencePriority?: number;// 0=unimportant, 1=most important
+}
+```
+
+### Capability Advertisement (2025-11-25)
+```json
+// Client declares:
+"sampling": {
+  "context": {},   // supports includeContext: "thisServer"/"allServers"
+  "tools": {}      // supports tools + toolChoice params
+}
+```
+- Server must check client has `sampling` capability before sending `sampling/createMessage`
+- If `tools` or `toolChoice` provided but client has no `sampling.tools`, client MUST return error
+- `includeContext` is soft-deprecated — only use `"none"` unless client declares `sampling.context`
+
+### SamplingMessage Content Types
+```typescript
+type SamplingMessageContentBlock =
+  | TextContent       // { type: "text", text: string }
+  | ImageContent      // { type: "image", data: string (base64), mimeType: string }
+  | AudioContent      // { type: "audio", data: string (base64), mimeType: string }
+  | ToolUseContent    // { type: "tool_use", id: string, name: string, input: {...} }
+  | ToolResultContent // { type: "tool_result", toolUseId: string, content: ContentBlock[], isError?: boolean }
+```
+
+### 2026-07-28 Changes (SEP-2577 — DEPRECATED)
+- `sampling/createMessage` **deprecated** but remains in schema for 12+ months
+- In 2026-07-28, server uses MRTR: returns `InputRequiredResult` with `inputRequests.key = CreateMessageRequest`
+- Client provides `inputResponses.key = CreateMessageResult` on retry
+- `SamplingMessage`, `CreateMessageRequest`, `CreateMessageResult`, `ModelPreferences`, `ToolUseContent`, `ToolResultContent`, `ToolChoice` all marked `@deprecated`
+
+### Gotchas / Advice
+- **`maxTokens` is required** — not optional. A server forgetting this causes client errors.
+- **Client has full discretion over model selection** — `modelPreferences` are advisory only.
+- **Human-in-the-loop**: Client SHOULD inform user before sampling AND before returning result. This is a security/trust requirement.
+- **`ToolResultContent.toolUseId` must match a previous `ToolUseContent.id`** — multi-turn tool use requires tracking IDs.
+- **`SamplingMessage.content` can be a single block OR an array** (`SamplingMessageContentBlock | SamplingMessageContentBlock[]`) — handle both in deserialization.
+- **Tool results must not be mixed with other content in the same message** — spec says mixing is invalid (client returns -32602).
+- **Conformance** (`tools-call-sampling`) tests that server can initiate sampling during a tool call.
+- **`stopReason: "toolUse"`** — new value added alongside classic ones; open string for provider-specific values.
+
+---
+
+## 7. Progress + Cancellation
+
+### Governing SEPs
+No dedicated SEP — core spec since inception. SEP-2575 modified cancellation direction.
+
+### JSON-RPC Shapes
+
+```json
+// Client request with progressToken
+{
+  "jsonrpc":"2.0","id":5,"method":"tools/call",
+  "params":{"name":"slow_tool","arguments":{},"_meta":{"progressToken":"tok-abc"}}
+}
+
+// Server sends progress notifications on SSE stream (or stdio)
+{ "jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tok-abc","progress":25,"total":100,"message":"Processing..."}  }
+{ "jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tok-abc","progress":100,"total":100,"message":"Done"} }
+
+// Cancellation (2025-11-25 — either side)
+{ "jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":5,"reason":"User clicked cancel"} }
+
+// Cancellation (2026-07-28 — client only, plus server for subscriptions/listen close)
+{ "jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":5,"reason":"User clicked cancel"} }
+```
+
+### ProgressToken Types
+```typescript
+type ProgressToken = string | number;
+```
+Server must echo the token exactly. Numeric tokens must remain numeric (don't stringify).
+
+### Transport-Layer Progress (Streamable HTTP)
+- Client sends POST with JSON body; server responds with SSE stream (text/event-stream)
+- Progress notifications arrive as SSE `data:` events on that stream before the final result
+- Multiple requests can share the same HTTP connection but each POST opens its own SSE stream
+- The final response is the last event on the SSE stream
+
+### 2026-07-28 Changes
+- **`requestId` in `CancelledNotificationParams` is now required** (was optional in 2025-11-25)
+- **Server MUST NOT use `notifications/cancelled` for anything other than closing a `subscriptions/listen` stream** — client-to-server cancel is the only direction for general requests
+- **`notifications/cancelled` in 2025-11-25**: `requestId?: RequestId` + optional `reason`; either side can send
+
+### Gotchas / Advice
+- **Progress must be monotonically increasing** — `progress` should only increase. `total` can be omitted when unknown.
+- **Server is NOT obligated to send progress** even if client provides `progressToken` — it's a request, not a requirement.
+- **Cancellation may arrive after request completes** — server must handle gracefully (ignore if already done).
+- **Client MUST NOT cancel the `initialize` request** (2025-11-25 only — stateful lifecycle).
+- **On Streamable HTTP**: Progress and server-initiated requests (sampling/elicitation) are multiplexed on the SSE stream opened by the POST. Server can send arbitrary JSON-RPC messages on that stream before the final result.
+- **Conformance** (`tools-call-with-progress`): Tool named `test_progress` must accept no args, emit ≥1 progress notification during execution.
+- **`message` in progress notification** is optional but useful for UX.
+
+---
+
+## 8. Roots
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-2577 (2026-07-28) | Entire roots feature deprecated |
+
+### JSON-RPC Shapes (2025-11-25 — server requests from client)
+
+```json
+// Server sends roots/list to client
+{ "jsonrpc":"2.0","id":200,"method":"roots/list","params":{} }
+
+// Client response
+{
+  "jsonrpc":"2.0","id":200,
+  "result":{ "roots":[{"uri":"file:///workspace/my-project","name":"My Project"}] }
+}
+
+// Server notification when roots change
+{ "jsonrpc":"2.0","method":"notifications/roots/list_changed","params":{} }
+```
+
+### Capability Advertisement (2025-11-25)
+```json
+// Client declares in initialize:
+"roots": {
+  "listChanged": true    // supports notifications/roots/list_changed
+}
+```
+- Server can only request `roots/list` if client declared `roots` capability
+- Server can only expect `notifications/roots/list_changed` if `listChanged: true`
+
+### 2026-07-28 Status
+- `roots/list`, `ListRootsRequest`, `ListRootsResult`, `Root`, `notifications/roots/list_changed` all marked **`@deprecated`** in 2026-07-28 schema (SEP-2577)
+- `roots` capability in `ClientCapabilities` deprecated
+- Remains in schema for 12+ months backward compatibility
+
+### Root URIs
+```typescript
+interface Root {
+  uri: string;    // MUST start with "file://" currently
+  name?: string;  // optional human-readable label
+}
+```
+- URIs currently restricted to `file://` scheme
+- This restriction may be relaxed in future versions
+
+### Gotchas / Advice
+- **Roots is server-to-client** — uncommon direction. Server must open SSE stream or use stdio to send this request.
+- **On Streamable HTTP**: Server can't spontaneously make requests; it can only send JSON-RPC requests on the SSE stream opened by a client POST. This limits roots usage — typically done during initialize handshake or as part of a tool call.
+- **`listChanged` must be declared by client** — if false/absent, server must not rely on getting change notifications.
+- **2026-07-28**: Implement for 2025-11-25 compatibility but mark it as deprecated and plan migration.
+- **No conformance test** in the conformance suite specifically for `roots/list` as a standalone scenario — it's tested implicitly via `tools-call-sampling`.
+
+---
+
+## 9. Streamable HTTP Transport + Stateless Lifecycle (2026-07-28)
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-2575 (Final, 2026-07-28) | Make MCP stateless: per-request `_meta`, `server/discover`, `subscriptions/listen` |
+| SEP-2243 | HTTP header standardization: `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`, case-insensitivity |
+| SEP-1699 | SSE polling: GET endpoint for multiple server-to-client streams (2025-11-25 only) |
+| GHSA-w48q-cv73-mx4w | DNS rebinding protection for localhost servers |
+
+### 2025-11-25 Transport Overview (Stateful)
+
+**Initialize Handshake Required:**
+```json
+// Step 1: Client POSTs initialize
+POST /mcp HTTP/1.1
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+Origin: http://localhost:3000
+
+{ "jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{...},"clientInfo":{...}} }
+
+// Server responds with MCP-Session-Id
+HTTP/1.1 200 OK
+Mcp-Session-Id: sess-abc123
+Content-Type: application/json
+{ "jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{...},"serverInfo":{...}} }
+
+// Step 2: Client sends initialized notification
+POST /mcp HTTP/1.1
+Mcp-Session-Id: sess-abc123
+{ "jsonrpc":"2.0","method":"notifications/initialized" }
+
+// Step 3: Normal requests
+POST /mcp HTTP/1.1
+Mcp-Session-Id: sess-abc123
+{ "jsonrpc":"2.0","id":2,"method":"tools/list" }
+```
+
+**SSE Streaming for Long Responses:**
+```
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+Cache-Control: no-cache
+
+data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tok","progress":50}}
+
+data: {"jsonrpc":"2.0","id":2,"result":{"tools":[...]}}
+```
+
+**GET Endpoint (SSE polling — SEP-1699, 2025-11-25):**
+```
+GET /mcp HTTP/1.1
+Mcp-Session-Id: sess-abc123
+Accept: text/event-stream
+
+// Server holds SSE connection open for server-initiated requests:
+data: {"jsonrpc":"2.0","id":99,"method":"sampling/createMessage","params":{...}}
+
+// Client responds to server-initiated request via POST:
+POST /mcp HTTP/1.1
+Mcp-Session-Id: sess-abc123
+{ "jsonrpc":"2.0","id":99,"result":{...} }
+```
+
+**Multiple SSE Streams (SEP-1699):**
+- Client can open multiple concurrent GET streams
+- Each stream gets notifications independently
+- Server acknowledges and tracks active streams
+- Conformance: `sse-multiple-streams` (2 checks)
+
+### 2026-07-28 Transport Overview (Stateless)
+
+**No initialize handshake — per-request `_meta`:**
+```json
+// Every request carries full identity and capabilities in _meta
+POST /mcp HTTP/1.1
+Content-Type: application/json
+MCP-Protocol-Version: 2026-07-28
+Accept: application/json, text/event-stream
+
+{
+  "jsonrpc":"2.0","id":1,"method":"tools/list",
+  "params":{
+    "_meta":{
+      "io.modelcontextprotocol/protocolVersion":"2026-07-28",
+      "io.modelcontextprotocol/clientInfo":{"name":"my-client","version":"1.0.0"},
+      "io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":{}}}
+    }
+  }
+}
+```
+
+**`server/discover` (replaces initialize for capability discovery):**
+```json
+// Client may call server/discover to learn capabilities before sending requests
+{ "jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{...}} }
+// Server response (CacheableResult):
+{
+  "resultType":"complete",
+  "supportedVersions":["2026-07-28","2025-11-25"],
+  "capabilities":{"tools":{},"resources":{},"prompts":{}},
+  "instructions":"This server...",
+  "ttlMs":3600000,
+  "cacheScope":"public",
+  "_meta":{"io.modelcontextprotocol/serverInfo":{"name":"my-server","version":"1.0"}}
+}
+```
+
+**`subscriptions/listen` (replaces GET SSE endpoint):**
+```json
+// Client opens long-lived stream for notifications
+POST /mcp HTTP/1.1
+Content-Type: application/json
+MCP-Protocol-Version: 2026-07-28
+
+{
+  "jsonrpc":"2.0","id":2,"method":"subscriptions/listen",
+  "params":{
+    "_meta":{...},
+    "notifications":{
+      "toolsListChanged":true,
+      "resourcesListChanged":true,
+      "resourceSubscriptions":["file:///watched.txt"]
+    }
+  }
+}
+
+// Server holds SSE open; first message MUST be acknowledged notification:
+data: {"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged","params":{"notifications":{"toolsListChanged":true,"resourcesListChanged":true,"resourceSubscriptions":["file:///watched.txt"]},"_meta":{"io.modelcontextprotocol/subscriptionId":2}}}
+
+// Subsequent notifications carry subscriptionId:
+data: {"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"file:///watched.txt","_meta":{"io.modelcontextprotocol/subscriptionId":2}}}
+
+// Server closes stream gracefully with SubscriptionsListenResult:
+data: {"jsonrpc":"2.0","id":2,"result":{"resultType":"complete","_meta":{"io.modelcontextprotocol/subscriptionId":2}}}
+```
+
+### Error Codes (2026-07-28 — new)
+```typescript
+const HEADER_MISMATCH = -32020;                    // HTTP 400
+const MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;  // HTTP 400
+const UNSUPPORTED_PROTOCOL_VERSION = -32022;        // HTTP 400
+```
+
+**`UnsupportedProtocolVersionError` example:**
+```json
+{
+  "error":{"code":-32022,"message":"Unsupported protocol version",
+    "data":{"supported":["2026-07-28","2025-11-25"],"requested":"2099-01-01"}}
+}
+```
+
+**`MissingRequiredClientCapabilityError` example:**
+```json
+{
+  "error":{"code":-32021,"message":"Client capability required",
+    "data":{"requiredCapabilities":{"sampling":{}}}}
+}
+```
+
+**`HeaderMismatchError` example (-32020):**
+Returned when `MCP-Protocol-Version` header doesn't match `_meta["io.modelcontextprotocol/protocolVersion"]`.
+
+### `resultType` Field (2026-07-28 Required)
+ALL results in 2026-07-28 MUST include `resultType`:
+```json
+{ "resultType":"complete", ... }    // success
+{ "resultType":"input_required", ... }  // MRTR
+```
+For backward compat: absent `resultType` from 2025-11-25 servers MUST be treated as `"complete"`.
+
+### SEP-2243 HTTP Headers
+| Header | Direction | Required | Notes |
+|--------|-----------|----------|-------|
+| `MCP-Protocol-Version` | Client→Server | Yes | Must match `_meta.io.mcp/protocolVersion` |
+| `Accept` | Client→Server | Recommended | `application/json, text/event-stream` |
+| `Content-Type` | Client→Server | Yes | `application/json` |
+| `Mcp-Method` | Client→Server | Yes (2026-07-28) | JSON-RPC method name |
+| `Mcp-Name` | Client→Server | Conditional | Tool name for `tools/call` |
+| `Mcp-Session-Id` | Both | Conditional | 2025-11-25 session identifier |
+
+Headers must be treated **case-insensitively**. Values must have leading/trailing whitespace trimmed. Mismatch between header and body → -32020.
+
+### DNS Rebinding Protection
+- **MUST** validate `Host` or `Origin` header on ALL incoming requests (localhost servers)
+- Reject non-localhost `Host`/`Origin` with HTTP 4xx
+- Accept: `localhost`, `127.0.0.1`, `[::1]` (with optional port)
+- Reject: anything else (e.g., `evil.example.com`)
+- Security advisory: `GHSA-w48q-cv73-mx4w` in typescript-sdk
+- Conformance: `dns-rebinding-protection` (2 checks: rejected attack + accepted valid)
+
+### Conformance Test Scenarios
+| Scenario | SEP | Checks |
+|----------|-----|--------|
+| `server-initialize` | — | Initialize handshake (2025-11-25) |
+| `server-stateless` | SEP-2575 | 22 checks covering all stateless requirements |
+| `session-lifecycle` | — | MCP-Session-Id handling |
+| `sse-multiple-streams` | SEP-1699 | Multiple concurrent GET SSE streams |
+| `dns-rebinding-protection` | GHSA | Reject evil.example.com, accept localhost |
+| `caching` | SEP-2549 | ttlMs/cacheScope on list results |
+
+### Gotchas / Advice
+- **Stateful (2025-11-25) and stateless (2026-07-28) are fundamentally different** — maintain both modes or decide on one. The conformance suite `--spec-version 2025-11-25` tests the stateful path; `--spec-version 2026-07-28` tests stateless.
+- **Server MUST NOT send notifications before `subscriptions/listen` — `notifications/subscriptions/acknowledged` MUST be the FIRST message** on any listen stream.
+- **`subscriptions/listen` subscription IDs** — the JSON-RPC `id` of the `subscriptions/listen` request IS the subscription ID. Echo it in `_meta["io.modelcontextprotocol/subscriptionId"]` on every notification.
+- **`server/discover` is required** in 2026-07-28 (`Servers MUST implement server/discover`).
+- **`io.modelcontextprotocol/clientInfo` is SHOULD-level** — servers must NOT reject requests that omit it.
+- **`io.modelcontextprotocol/clientCapabilities` is required** — empty object `{}` means no optional capabilities.
+- **MRTR on HTTP**: Server-to-client requests (elicitation, sampling) happen via `InputRequiredResult` on the same HTTP response — no separate SSE stream needed for them in 2026-07-28.
+- **Duplicate in-flight request IDs** (typescript-sdk PR#2434): Server must reject a POST containing a request ID that's already in-flight with HTTP 400 + -32600. Cancelled requests must retire their ID.
+- **`subscriptions/listen` closure**: Server sends `SubscriptionsListenResult` gracefully on shutdown; abrupt close has no response.
+- **`notifications/cancelled` on stdio**: Server can send it to close a `subscriptions/listen` stream, referencing the stream's request ID.
+
+---
+
+## 10. structuredContent + Tool Output Schemas + Content Types
+
+### Governing SEPs
+| SEP | Description |
+|-----|-------------|
+| SEP-1613 | JSON Schema 2020-12 for tool schemas |
+| SEP-2106 | JSON Schema network `$ref` dereferencing |
+
+### JSON-RPC Shapes
+
+```json
+// Tool definition with outputSchema (in tools/list result)
+{
+  "name":"analyze_data",
+  "description":"Analyzes data and returns structured results",
+  "inputSchema":{
+    "type":"object",
+    "properties":{"data":{"type":"string"}},
+    "required":["data"]
+  },
+  "outputSchema":{
+    "$schema":"https://json-schema.org/draft/2020-12/schema",
+    "type":"object",
+    "properties":{
+      "sentiment":{"type":"string","enum":["positive","negative","neutral"]},
+      "confidence":{"type":"number"}
+    },
+    "required":["sentiment","confidence"]
+  },
+  "annotations":{
+    "title":"Data Analyzer",
+    "readOnlyHint":true,
+    "destructiveHint":false,
+    "idempotentHint":true,
+    "openWorldHint":false
+  }
+}
+
+// tools/call result with structured + unstructured content
+{
+  "content":[
+    {"type":"text","text":"Analysis complete: positive sentiment (0.92)"}
+  ],
+  "structuredContent":{
+    "sentiment":"positive",
+    "confidence":0.92
+  }
+}
+
+// tools/call result with error (isError: true — NOT a JSON-RPC error)
+{
+  "content":[{"type":"text","text":"Error: file not found"}],
+  "isError":true
+}
+
+// tools/call result with image content
+{
+  "content":[
+    {"type":"image","data":"<base64>","mimeType":"image/png"},
+    {"type":"text","text":"Chart generated"}
+  ]
+}
+
+// tools/call result with audio content
+{ "content":[{"type":"audio","data":"<base64>","mimeType":"audio/wav"}] }
+
+// tools/call result with embedded resource
+{
+  "content":[{
+    "type":"resource",
+    "resource":{"uri":"file:///result.csv","mimeType":"text/csv","text":"a,b,c\n1,2,3"}
+  }]
+}
+
+// tools/call result with resource link (reference, not embedded)
+{
+  "content":[{
+    "type":"resource_link",
+    "uri":"file:///report.pdf","name":"Report","mimeType":"application/pdf"
+  }]
+}
+```
+
+### ContentBlock Union
+```typescript
+type ContentBlock =
+  | TextContent        // type: "text", text: string
+  | ImageContent       // type: "image", data: string (base64), mimeType: string
+  | AudioContent       // type: "audio", data: string (base64), mimeType: string
+  | ResourceLink       // type: "resource_link", uri, name, ...Resource fields
+  | EmbeddedResource   // type: "resource", resource: TextResourceContents | BlobResourceContents
+```
+
+### Error Semantics — Critical Rules
+1. **Tool errors from the tool itself** → `isError: true` in `CallToolResult.content`, NOT a JSON-RPC error
+2. **Unknown tool name** → `-32602 InvalidParams` (NOT `-32601 MethodNotFound`)
+3. **`tools` capability not declared** → `-32601 MethodNotFound`
+4. **Server doesn't support tool calls** → `-32601 MethodNotFound`
+
+Per 2026-07-28 schema comment on `InvalidParamsError` (-32602):
+> "**Tools**: Unknown tool name or invalid tool arguments"
+
+This is explicitly NOT -32601.
+
+### `isError` Semantics
+- `isError: true` means the tool ran but the invocation produced an error
+- LLM sees the error content and can self-correct
+- `isError: false` (or absent) = success
+- Do NOT throw JSON-RPC errors for tool-level failures
+
+### `outputSchema` Evolution
+- **2025-11-25**: Restricted to `{ type: "object", ... }` at root level
+- **2026-07-28**: Any valid JSON Schema 2020-12 (`outputSchema?: { $schema?: string; [key: string]: unknown }`)
+- `structuredContent` in 2026-07-28 is `unknown` (any JSON value, not just object)
+
+### ToolAnnotations (Hints Only)
+```typescript
+interface ToolAnnotations {
+  title?: string;           // display name (precedence: title > annotations.title > name)
+  readOnlyHint?: boolean;   // default: false
+  destructiveHint?: boolean;// default: true
+  idempotentHint?: boolean; // default: false
+  openWorldHint?: boolean;  // default: true
+}
+```
+**These are HINTS, not guarantees.** Clients MUST NOT make security decisions based on them.
+
+### Conformance Test Scenarios
+| Scenario | Description |
+|----------|-------------|
+| `tools-list` | Lists tools; validates inputSchema |
+| `tools-call-simple-text` | Returns `{"type":"text","text":"..."}` |
+| `tools-call-image` | Returns image content block |
+| `tools-call-audio` | Returns audio content block |
+| `tools-call-embedded-resource` | Returns embedded resource |
+| `tools-call-mixed-content` | Returns multiple content types |
+| `tools-call-error` | Returns `isError: true` |
+| `json-schema-2020-12` | Tool with `$schema` + `$defs` + `additionalProperties` (SEP-1613) |
+
+### Gotchas / Advice
+- **`content` array is required even when `structuredContent` is present** — unstructured content is the primary representation.
+- **Unknown tool → -32602, not -32601** — this is a CRITICAL and non-obvious requirement. mcptools likely gets this wrong.
+- **`annotations.title` vs `Tool.title`**: Display precedence is `Tool.title > annotations.title > Tool.name`. Both exist for backward compat.
+- **JSON Schema 2020-12 default** — if `$schema` is absent from `inputSchema`, it defaults to JSON Schema 2020-12. SDKs that hardcode draft-07 behavior break SEP-1613.
+- **Binary/audio content**: `data` is standard base64, not URL-safe. `mimeType` is required.
+- **`ResourceLink` in tool results** is NOT guaranteed to appear in `resources/list` — spec explicitly notes this.
+- **`EmbeddedResource.type` is `"resource"`** — same as in prompts. Don't confuse with `ResourceLink.type = "resource_link"`.
+- **`Annotations.lastModified`** format: ISO 8601 string (e.g., `"2025-01-12T15:00:58Z"`).
+
+---
+
+## Cross-Cutting Concerns
+
+### Version Negotiation (2025-11-25 Stateful)
+1. Client sends `protocolVersion: "2025-11-25"` in initialize
+2. Server responds with the version it supports (may be lower)
+3. If client can't support server's version → client MUST disconnect
+4. Supported versions in the codebase: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25
+
+### Version Negotiation (2026-07-28 Stateless)
+1. Client sends `MCP-Protocol-Version: 2026-07-28` header AND `_meta["io.modelcontextprotocol/protocolVersion"]: "2026-07-28"`
+2. If mismatch between header and body → -32020 HeaderMismatch
+3. If unsupported version → -32022 UnsupportedProtocolVersion with `data.supported` array
+4. Client can call `server/discover` first to learn what versions the server supports
+
+### Pagination (Cursor-Based)
+- Cursor is an **opaque string** — implementation-defined encoding
+- Absent `cursor` in request = first page
+- Absent `nextCursor` in result = last page
+- Expired/invalid cursor → -32602 InvalidParams
+- Cursors are NOT guaranteed stable across server restarts
+
+### `_meta` Field
+- Optional additional metadata on requests, responses, notifications
+- Key naming rules (2026-07-28): `[prefix/]name` format; prefix uses reverse DNS; `io.modelcontextprotocol/` and `dev.mcp/` are reserved
+- Clients and servers MUST NOT make assumptions about unknown `_meta` keys
+
+---
+
+## Conformance Test Command Reference
+
+```bash
+# Run all server scenarios (2025-11-25)
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp
+
+# Run for specific spec version
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --spec-version 2025-11-25
+
+# Run stateless (2026-07-28) scenarios
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --spec-version 2026-07-28
+
+# Run specific scenario
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --scenario elicitation-sep1034-defaults
+
+# Run elicitation scenarios
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --scenario elicitation-sep1034-defaults
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --scenario elicitation-sep1330-enums
+```
+
+---
+
+## Key SDK PRs for Reference
+
+| PR | Repo | Feature |
+|----|------|---------|
+| modelcontextprotocol/typescript-sdk#2184 | typescript-sdk | SEP-2575 stateless lifecycle |
+| modelcontextprotocol/typescript-sdk#2434 | typescript-sdk | Reject duplicate in-flight request IDs in Streamable HTTP |
+| modelcontextprotocol/typescript-sdk#2174 | typescript-sdk | Fix streamable HTTP transport restart after close |
+| modelcontextprotocol/typescript-sdk#2578 | typescript-sdk | MRTR app-rendered elicitation example (draft) |
+| modelcontextprotocol/python-sdk#2804 | python-sdk | SEP-2575 stateless lifecycle |
+| modelcontextprotocol/python-sdk#3063 | python-sdk | Reject duplicate in-flight request IDs |
+| modelcontextprotocol/modelcontextprotocol#2575 | spec | SEP-2575: Make MCP Stateless |
+| modelcontextprotocol/modelcontextprotocol#3039 | spec | Docs: reflect stateless protocol |
+| modelcontextprotocol/modelcontextprotocol#3159 | spec | Docs: post-final SEP-2575 changes |
+| modelcontextprotocol/modelcontextprotocol#3002 | spec | Make clientInfo optional, serverInfo to _meta |
+| modelcontextprotocol/modelcontextprotocol#2953 | spec | subscriptions/listen result for graceful closure |
+
+---
+
+## Suggested Build Order & Parallelization
+
+### Phase 1 — Fully Independent (can be built in parallel)
+
+These feature areas share no code and have no ordering dependencies:
+
+| Workstream A | Workstream B | Workstream C |
+|---|---|---|
+| **Resources** (list, read, templates, subscribe/unsubscribe) | **Prompts** (list, get + all content types) | **Completion** (complete, both ref types) |
+
+**Rationale:** Resources need their own storage/routing. Prompts have their own message assembly. Completion is a thin autocomplete layer over prompt/template lookup. All three are pure server-side features with no client-capability negotiation complexity.
+
+### Phase 2 — After Phase 1, Also Parallelizable
+
+| Workstream D | Workstream E |
+|---|---|
+| **Logging** (setLevel + notifications/message) | **Progress + Cancellation** (progressToken extraction, notification dispatch, cancel handler) |
+
+**Rationale:** Logging requires the notification dispatch infrastructure, but it's otherwise independent. Progress requires the SSE/stream infrastructure already built for resources.
+
+### Phase 3 — Sequential (each depends on prior phases)
+
+1. **Streamable HTTP Transport** — must be done before elicitation/sampling because the SSE multiplexing is needed to carry server-to-client requests. DNS rebinding protection goes here too.
+
+2. **structuredContent + Tool Schemas** — depends on the tool dispatch infrastructure. Build after transport layer is solid.
+
+3. **Elicitation** (2025-11-25 mode) — depends on transport (SSE stream must be open), must come after structuredContent work is stable. Implement the `test_elicitation_sep1034_defaults` and `test_elicitation_sep1330_enums` tools.
+
+4. **Sampling** (2025-11-25 mode) — depends on the same SSE multiplexing as elicitation. Can be parallelized with elicitation.
+
+5. **Roots** — depends on transport (server-to-client request). Can be parallelized with elicitation/sampling.
+
+### Phase 4 — Optional/2026-07-28 Only
+
+| Feature | Dependencies |
+|---------|-------------|
+| **Stateless lifecycle** (server/discover, per-request _meta) | Requires all Phase 1-3 features to be rearchitected |
+| **subscriptions/listen** | Requires stateless lifecycle |
+| **MRTR (InputRequiredResult)** | Requires elicitation + sampling + stateless lifecycle |
+
+### Dependency Graph Summary
+
+```
+Resources ─┐
+Prompts ────┤
+Completion ─┤─→ Logging ──┐
+            │   Progress ──┤─→ Streamable HTTP ─→ structuredContent ─→ Elicitation ─→ Sampling ─→ Roots
+            │              │                                            └─────────────→ Sampling (parallel)
+            └──────────────┘
+
+For 2026-07-28 only:
+Streamable HTTP → Stateless Lifecycle → subscriptions/listen → MRTR
+```
+
+### What's Safe to Parallelize Right Now (for R SDK fork)
+1. **Session A**: Resources + binary blob handling + pagination cursor
+2. **Session B**: Prompts (all content types) + completion
+3. **Session C**: Logging + basic notification infrastructure
+4. **Session D**: Progress token extraction + cancellation handler
+5. **After A-D merge**: Session E for Streamable HTTP transport; Session F for tool content types + outputSchema + isError semantics
+6. **After E-F merge**: Session G for elicitation (SEP-1034 + SEP-1330); Session H for sampling
+```
+
+---
+
+## Summary of Biggest Gotchas
+
+**Found during research — these are the most impactful implementation traps:**
+
+1. **Unknown tool name is -32602, NOT -32601** (`modelcontextprotocol/modelcontextprotocol:schema/2026-07-28/schema.ts` — `InvalidParamsError` comment explicitly names "Unknown tool name"; `MethodNotFoundError` is for unsupported methods/capabilities). mcptools almost certainly returns -32601 here.
+
+2. **Elicitation requires flat schema only** — no nested objects. `requestedSchema.properties` values are `PrimitiveSchemaDefinition`, not arbitrary JSON Schema.
+
+3. **SEP-1034 default values for enum must be a valid enum member** — conformance test validates this explicitly.
+
+4. **SEP-1330 titled single-select uses `oneOf` (not `enum`)** but untitled uses `enum`. Titled multi-select uses `items.anyOf` (not `items.oneOf`). Easy to mix up.
+
+5. **2026-07-28 `resultType` is required in ALL results** — absent = backward compat (treat as "complete"), but implementing servers must include it.
+
+6. **`subscriptions/listen` acknowledged notification MUST be first** — no other notifications before it, even on stdio where streams interleave.
+
+7. **`subscriptions/listen` replaces both GET SSE endpoint AND `resources/subscribe`/`resources/unsubscribe`** — three separate 2025-11-25 mechanisms collapse into one in 2026-07-28.
+
+8. **Sampling `maxTokens` is required** (not optional), and `SamplingMessage.content` is `Block | Block[]` (both shapes must be handled in deserialization).
+
+9. **DNS rebinding protection**: Must check `Host` OR `Origin` header on localhost. Advisory GHSA-w48q-cv73-mx4w shows this is a real exploit vector.
+
+10. **`server/discover` is REQUIRED in 2026-07-28** — `Servers MUST implement server/discover` (per scenario description for `server-stateless`).
+
+11. **`io.modelcontextprotocol/clientInfo` is SHOULD** — servers must NOT reject requests that omit it (PR#3002 change after SEP-2575 was finalized).
+
+12. **Binary content** (`blob`, `data`) must be standard base64 (not URL-safe). Mimetypes are required on binary content.
+
+13. **`isError: true` keeps the LLM in the loop** — if you throw a JSON-RPC error for tool failures, the LLM never sees the error and cannot self-correct.
+
+14. **Caching (SEP-2549)**: In 2026-07-28, `ttlMs` and `cacheScope` are required fields on all list results and `ReadResourceResult`. Forgetting them is a wire-schema violation.
+
+15. **Duplicate request IDs** in Streamable HTTP: Server must reject a POST containing an already-in-flight request ID with HTTP 400 + -32600. But sequential reuse after completion is allowed (typescript-sdk PR#2434).
+
+---
+
+## Citations
+
+- Schema (2025-11-25): `modelcontextprotocol/modelcontextprotocol:schema/2025-11-25/schema.ts`
+- Schema (2026-07-28): `modelcontextprotocol/modelcontextprotocol:schema/2026-07-28/schema.ts`
+- Conformance scenarios index: `modelcontextprotocol/conformance:src/scenarios/index.ts`
+- Elicitation defaults conformance: `modelcontextprotocol/conformance:src/scenarios/server/elicitation-defaults.ts`
+- Elicitation enums conformance: `modelcontextprotocol/conformance:src/scenarios/server/elicitation-enums.ts`
+- Resources conformance: `modelcontextprotocol/conformance:src/scenarios/server/resources.ts`
+- DNS rebinding conformance: `modelcontextprotocol/conformance:src/scenarios/server/dns-rebinding.ts`
+- Stateless conformance: `modelcontextprotocol/conformance:src/scenarios/server/stateless.ts`
+- SEP-2575 tracking: `modelcontextprotocol/modelcontextprotocol#2884`
+- SEP-2575 post-final changes: `modelcontextprotocol/modelcontextprotocol#3159`
+- SEP-1034 (conformance ref): `modelcontextprotocol/modelcontextprotocol#1034`
+- SEP-1330 (conformance ref): `modelcontextprotocol/modelcontextprotocol#1330`
+- TypeScript SDK stateless: `modelcontextprotocol/typescript-sdk#2184`
+- TypeScript SDK duplicate IDs: `modelcontextprotocol/typescript-sdk#2434`
+- Python SDK stateless: `modelcontextprotocol/python-sdk#2804`
+- Ruby SDK tier assessment (full conformance scenario list): `modelcontextprotocol/modelcontextprotocol#3127`

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Run the official MCP conformance suite (server mode) against the forked
+# mcptools everything-server.
+#
+# Boots conformance/everything-server.R on a local port, waits for it to
+# accept requests, runs the conformance harness, saves the output, and tears
+# the server down.
+#
+# Env overrides:
+#   MCP_HOST              bind host (default 127.0.0.1)
+#   MCP_PORT              bind port (default 3001)
+#   SPEC_VERSION          spec version to test (default 2025-11-25)
+#   SUITE                 conformance suite (default all)
+#   CONFORMANCE_VERSION   npm harness version (defaults per spec version)
+#   EXPECTED              expected-failures file (version-specific by default)
+#   OUT                   output file (default conformance/last-run-<spec>.txt)
+#   SERVER_LOG            server log (default conformance/server-<spec>.log)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+
+# ---- Library isolation -----------------------------------------------------
+# Load the worktree-local build (see Makefile `install`) ahead of the shared
+# user library so parallel worktrees don't load each other's package. Capture
+# the *original* libpaths first (for dependency resolution), before overriding.
+RLIB="${RLIB:-$REPO/.Rlib}"
+if [ -d "$RLIB" ]; then
+  ORIG_LIBS="$(Rscript -e 'cat(paste(.libPaths(), collapse=":"))' 2>/dev/null || true)"
+  export R_LIBS_USER="$RLIB:$ORIG_LIBS"
+fi
+
+HOST="${MCP_HOST:-127.0.0.1}"
+# Pick an ephemeral port by default so concurrent runs don't collide.
+if [ -n "${MCP_PORT:-}" ]; then
+  PORT="$MCP_PORT"
+else
+  PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || true)"
+  [ -z "$PORT" ] && PORT=$(( (RANDOM % 20000) + 20000 ))
+fi
+SPEC="${SPEC_VERSION:-2025-11-25}"
+SUITE="${SUITE:-all}"
+if [ "${CONFORMANCE_VERSION+x}" = "x" ]; then
+  CONF_VER="$CONFORMANCE_VERSION"
+elif [ "$SPEC" = "2026-07-28" ]; then
+  CONF_VER="0.2.0-alpha.10"
+else
+  CONF_VER="0.1.16"
+fi
+OUT="${OUT:-$HERE/last-run-${SPEC}.txt}"
+SERVER_LOG="${SERVER_LOG:-$HERE/server-${SPEC}.log}"
+# Expected-failures baseline (the ratchet). Set EXPECTED="" to disable.
+if [ "${EXPECTED+x}" = "x" ]; then
+  EXPECTED_FILE="$EXPECTED"
+elif [ "$SPEC" = "2026-07-28" ]; then
+  EXPECTED_FILE="$HERE/expected-failures-2026-07-28.yml"
+else
+  EXPECTED_FILE="$HERE/expected-failures.yml"
+fi
+
+echo "[run] launching everything-server on ${HOST}:${PORT}"
+MCP_HOST="$HOST" MCP_PORT="$PORT" Rscript "$HERE/everything-server.R" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "[run] waiting for http://${HOST}:${PORT}/mcp ..."
+ready=0
+for _ in $(seq 1 120); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "[run] ERROR: server process exited early; log follows:" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+  fi
+  code="$(curl -s -o /dev/null -w '%{http_code}' -m 2 -X POST "http://${HOST}:${PORT}/mcp" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H "MCP-Protocol-Version: ${SPEC}" \
+    -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"'"${SPEC}"'","capabilities":{},"clientInfo":{"name":"readiness","version":"0"}}}' 2>/dev/null || true)"
+  if [ -n "$code" ] && [ "$code" != "000" ]; then ready=1; break; fi
+  sleep 0.5
+done
+if [ "$ready" -ne 1 ]; then
+  echo "[run] ERROR: server did not become ready" >&2
+  cat "$SERVER_LOG" >&2
+  exit 1
+fi
+
+EXPECTED_ARGS=()
+if [ -n "$EXPECTED_FILE" ] && [ -f "$EXPECTED_FILE" ]; then
+  EXPECTED_ARGS=(--expected-failures "$EXPECTED_FILE")
+  echo "[run] using expected-failures baseline: ${EXPECTED_FILE}"
+fi
+
+echo "[run] running conformance@${CONF_VER} server suite=${SUITE} spec=${SPEC}"
+npx -y "@modelcontextprotocol/conformance@${CONF_VER}" server \
+  --url "http://${HOST}:${PORT}/mcp" \
+  --suite "$SUITE" \
+  --spec-version "$SPEC" \
+  "${EXPECTED_ARGS[@]}" | tee "$OUT"
+RC=${PIPESTATUS[0]}
+
+echo "[run] harness exit=${RC}; output saved to ${OUT}"
+exit "$RC"

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -96,7 +96,9 @@ mcp_server(type = "http")
 mcp_server(type = "http", host = "127.0.0.1", port = 9000)
 }\if{html}{\out{</div>}}
 
-The server will listen for HTTP POST requests containing JSON-RPC messages.
+The server implements MCP Streamable HTTP, including stateful sessions,
+streaming POST responses, and resumable GET event streams on local IPv4
+listeners.
 }
 
 \subsection{Posit Connect}{

--- a/tests/testthat/test-client-auth.R
+++ b/tests/testthat/test-client-auth.R
@@ -445,6 +445,90 @@ test_that("dynamic client registration caches the registered client", {
   expect_equal(register_calls, 1L)
 })
 
+# OAuth: registration priority (pre-registration > CIMD > DCR) -----------------
+test_that("static client_id/client_secret pre-registration wins over DCR", {
+  transport <- mcp_transport_http(list(
+    url = "https://example.test/mcp",
+    oauth = list(client_id = "static-client", client_secret = "shhh")
+  ))
+  # a registration_endpoint is advertised, but static credentials take priority
+  metadata <- list(
+    registration_endpoint = "https://auth.test/register",
+    client_id_metadata_document_supported = TRUE
+  )
+
+  local_mocked_bindings(
+    mcp_oauth_register_client = function(...) stop("DCR must not run")
+  )
+
+  info <- mcp_oauth_client_info(transport, metadata, scope = NULL)
+  expect_equal(info$client_id, "static-client")
+  expect_equal(info$client_secret, "shhh")
+})
+
+test_that("CIMD is used when advertised, ahead of deprecated DCR", {
+  transport <- mcp_transport_http(list(
+    url = "https://example.test/mcp",
+    oauth = list(client_id_metadata_document = "https://app.example.com/client.json")
+  ))
+  metadata <- list(
+    registration_endpoint = "https://auth.test/register",
+    client_id_metadata_document_supported = TRUE
+  )
+
+  local_mocked_bindings(
+    mcp_oauth_register_client = function(...) stop("DCR must not run when CIMD is available")
+  )
+
+  info <- mcp_oauth_client_info(transport, metadata, scope = NULL)
+  expect_equal(info$client_id, "https://app.example.com/client.json")
+  expect_null(info$client_secret)
+})
+
+test_that("CIMD falls back to DCR when the server does not advertise support", {
+  transport <- mcp_transport_http(list(
+    url = "https://example.test/mcp",
+    oauth = list(client_id_metadata_document = "https://app.example.com/client.json")
+  ))
+  metadata <- list(registration_endpoint = "https://auth.test/register")
+
+  local_mocked_bindings(
+    mcp_oauth_register_client = function(...) list(client_id = "dcr-client")
+  )
+
+  info <- mcp_oauth_client_info(transport, metadata, scope = NULL)
+  expect_equal(info$client_id, "dcr-client")
+})
+
+test_that("client_id_metadata_document must be an https URL with a path", {
+  expect_error(
+    mcp_config_oauth(list(oauth = list(
+      client_id_metadata_document = "https://app.example.com"
+    ))),
+    "client_id_metadata_document"
+  )
+  expect_error(
+    mcp_config_oauth(list(oauth = list(
+      client_id_metadata_document = "http://app.example.com/client.json"
+    ))),
+    "client_id_metadata_document"
+  )
+  oauth <- mcp_config_oauth(list(oauth = list(
+    client_id_metadata_document = "https://app.example.com/client.json"
+  )))
+  expect_equal(
+    oauth$client_id_metadata_document,
+    "https://app.example.com/client.json"
+  )
+})
+
+test_that("client_secret requires client_id", {
+  expect_error(
+    mcp_config_oauth(list(oauth = list(client_secret = "shhh"))),
+    "client_secret"
+  )
+})
+
 test_that("mcp_transport_http_send retries once after a 401 and succeeds", {
   transport <- mcp_transport_http(list(
     url = "https://example.test/mcp",

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -135,6 +135,31 @@ test_that("HTTP requests reject unsupported MCP-Protocol-Version headers", {
   expect_match(res$body, "Invalid or unsupported MCP-Protocol-Version")
 })
 
+test_that("HTTP ping returns an empty object", {
+  res <- handle_http_request_message(
+    list(jsonrpc = "2.0", id = 1, method = "ping"),
+    protocol_version = "2025-11-25"
+  )
+
+  expect_equal(as.character(to_json(res$result)), "{}")
+})
+
+test_that("HTTP initialize issues a visible ASCII session ID", {
+  res <- handle_http_request(local_http_post_request(list(
+    jsonrpc = "2.0",
+    id = 1,
+    method = "initialize",
+    params = list(
+      protocolVersion = "2025-11-25",
+      capabilities = named_list(),
+      clientInfo = list(name = "test", version = "1")
+    )
+  )))
+
+  expect_equal(res$status, 200L)
+  expect_match(res$headers$`MCP-Session-Id`, "^[!-~]+$")
+})
+
 test_that("HTTP tools/list honors MCP-Protocol-Version header", {
   old_server_tools <- the$server_tools
   withr::defer(the$server_tools <- old_server_tools)
@@ -195,6 +220,167 @@ test_that("HTTP tools/call honors MCP-Protocol-Version header", {
   expect_equal(res$status, 200L)
   expect_null(body$result$structuredContent)
   expect_equal(body$result$content[[1]]$text, "0.92")
+})
+
+test_that("HTTP logging tool returns notifications and result as buffered SSE", {
+  old_server_tools <- the$server_tools
+  old_sessions_enabled <- the$sessions_enabled
+  withr::defer({
+    the$server_tools <- old_server_tools
+    the$sessions_enabled <- old_sessions_enabled
+  })
+
+  tool <- ellmer::tool(
+    function() "ok",
+    "Logging tool",
+    name = "test_tool_with_logging"
+  )
+  set_server_tools(list(tool), session_tools = FALSE)
+  the$sessions_enabled <- FALSE
+
+  res <- handle_http_request(local_http_post_request(
+    list(
+      jsonrpc = "2.0",
+      id = 1,
+      method = "tools/call",
+      params = list(
+        name = "test_tool_with_logging",
+        arguments = named_list()
+      )
+    ),
+    HTTP_ACCEPT = "application/json, text/event-stream"
+  ))
+
+  expect_equal(res$status, 200L)
+  expect_equal(res$headers$`Content-Type`, "text/event-stream")
+  expect_equal(
+    lengths(regmatches(
+      res$body,
+      gregexpr("notifications/message", res$body, fixed = TRUE)
+    )),
+    3L
+  )
+  expect_match(
+    res$body,
+    "Tool with logging executed successfully",
+    fixed = TRUE
+  )
+})
+
+test_that("HTTP progress tool echoes its token after buffered notifications", {
+  old_server_tools <- the$server_tools
+  old_sessions_enabled <- the$sessions_enabled
+  withr::defer({
+    the$server_tools <- old_server_tools
+    the$sessions_enabled <- old_sessions_enabled
+  })
+
+  tool <- ellmer::tool(
+    function() "ok",
+    "Progress tool",
+    name = "test_tool_with_progress"
+  )
+  set_server_tools(list(tool), session_tools = FALSE)
+  the$sessions_enabled <- FALSE
+
+  res <- handle_http_request(local_http_post_request(
+    list(
+      jsonrpc = "2.0",
+      id = 1,
+      method = "tools/call",
+      params = list(
+        name = "test_tool_with_progress",
+        arguments = named_list(),
+        `_meta` = list(progressToken = "progress-test-1")
+      )
+    ),
+    HTTP_ACCEPT = "text/event-stream"
+  ))
+
+  expect_equal(res$status, 200L)
+  expect_equal(res$headers$`Content-Type`, "text/event-stream")
+  expect_equal(
+    lengths(regmatches(
+      res$body,
+      gregexpr("notifications/progress", res$body, fixed = TRUE)
+    )),
+    3L
+  )
+  expect_match(res$body, '"progress":0', fixed = TRUE)
+  expect_match(res$body, '"progress":50', fixed = TRUE)
+  expect_match(res$body, '"progress":100', fixed = TRUE)
+  expect_match(res$body, '"text":"progress-test-1"', fixed = TRUE)
+})
+
+test_that("HTTP only buffers SSE for opted-in conformance tools", {
+  old_server_tools <- the$server_tools
+  old_sessions_enabled <- the$sessions_enabled
+  withr::defer({
+    the$server_tools <- old_server_tools
+    the$sessions_enabled <- old_sessions_enabled
+  })
+
+  tool <- ellmer::tool(function() "ok", "Other tool", name = "other_tool")
+  set_server_tools(list(tool), session_tools = FALSE)
+  the$sessions_enabled <- FALSE
+
+  res <- handle_http_request(local_http_post_request(
+    list(
+      jsonrpc = "2.0",
+      id = 1,
+      method = "tools/call",
+      params = list(name = "other_tool", arguments = named_list())
+    ),
+    HTTP_ACCEPT = "application/json, text/event-stream"
+  ))
+
+  expect_equal(res$headers$`Content-Type`, "application/json")
+  expect_equal(
+    jsonlite::parse_json(res$body)$result$content[[1]]$text,
+    "ok"
+  )
+})
+
+test_that("raw HTTP parsing waits for a complete UTF-8 request body", {
+  body <- charToRaw('{"message":"caf\u00e9"}')
+  headers <- charToRaw(paste0(
+    "POST /mcp HTTP/1.1\r\n",
+    "Host: 127.0.0.1\r\n",
+    "Content-Length: ", length(body), "\r\n\r\n"
+  ))
+  split <- which(body == as.raw(0xc3))[[1]]
+
+  expect_null(raw_http_parse_request(c(headers, body[seq_len(split)])))
+
+  parsed <- raw_http_parse_request(c(headers, body))
+  expect_equal(parsed$body, '{"message":"caf\u00e9"}')
+})
+
+test_that("raw HTTP parsing rejects embedded NUL bytes", {
+  body <- as.raw(c(0x7b, 0x22, 0x61, 0x22, 0x3a, 0x00, 0x7d))
+  request <- c(
+    charToRaw(paste0(
+      "POST /mcp HTTP/1.1\r\n",
+      "Host: 127.0.0.1\r\n",
+      "Content-Length: ", length(body), "\r\n\r\n"
+    )),
+    body
+  )
+
+  parsed <- raw_http_parse_request(request)
+  expect_s3_class(parsed, "raw_http_parse_error")
+  expect_equal(parsed$message, "Invalid HTTP request body")
+})
+
+test_that("buffered HTTP parsing rejects embedded NUL bytes", {
+  body <- as.raw(c(0x7b, 0x22, 0x61, 0x22, 0x3a, 0x00, 0x7d))
+  res <- handle_http_request(list(
+    REQUEST_METHOD = "POST",
+    rook.input = list(read = function() body)
+  ))
+
+  expect_equal(res$status, 400L)
+  expect_match(res$body, "Invalid HTTP request body", fixed = TRUE)
 })
 
 test_that("HTTP missing MCP-Protocol-Version does not inherit global state", {
@@ -357,7 +543,8 @@ test_that("forward_request returns append_tool_fn errors", {
   ))
 
   expect_s3_class(res, "jsonrpc_error")
-  expect_equal(res$error$message, "Method not found")
+  expect_equal(res$error$code, -32602)
+  expect_equal(res$error$message, "Unknown tool: missing_tool")
 })
 
 test_that("forward_request times out when session does not respond", {

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -316,6 +316,47 @@ test_that("as_tool_call_result handles mixed ellmer content", {
   expect_false(output$result$isError)
 })
 
+test_that("as_tool_call_result preserves plain MCP content blocks", {
+  data <- list(id = 1, protocolVersion = "2025-11-25")
+  audio <- list(
+    type = "audio",
+    data = "audio-data",
+    mimeType = "audio/wav"
+  )
+  resource <- list(
+    type = "resource",
+    resource = list(
+      uri = "test://resource",
+      mimeType = "text/plain",
+      text = "resource text"
+    )
+  )
+
+  audio_output <- as_tool_call_result(data, audio)
+  mixed_output <- as_tool_call_result(
+    data,
+    list(
+      list(type = "text", text = "caption"),
+      audio,
+      resource
+    )
+  )
+
+  expect_identical(audio_output$result$content, list(audio))
+  expect_null(audio_output$result$structuredContent)
+  expect_false(audio_output$result$isError)
+  expect_identical(
+    mixed_output$result$content,
+    list(
+      list(type = "text", text = "caption"),
+      audio,
+      resource
+    )
+  )
+  expect_null(mixed_output$result$structuredContent)
+  expect_false(mixed_output$result$isError)
+})
+
 test_that("as_tool_call_result handles vector results", {
   data <- list(id = 1)
   result <- c("line1", "line2", "line3")

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -102,6 +102,34 @@ test_that("tool_as_json includes annotations", {
   expect_equal(res$annotations[names(expected_annotations)], expected_annotations)
 })
 
+test_that("tool_as_json preserves raw input schemas", {
+  tool <- ellmer::tool(
+    function() "ok",
+    "Uses a raw schema",
+    name = "raw_schema"
+  )
+  schema <- list(
+    `$schema` = "https://json-schema.org/draft/2020-12/schema",
+    type = "object",
+    `$defs` = list(
+      value = list(`$anchor` = "valueDef", type = "string")
+    ),
+    allOf = list(list(anyOf = list(
+      list(required = list("phone")),
+      list(required = list("email"))
+    ))),
+    `if` = list(properties = list(mode = list(const = "phone"))),
+    then = list(required = list("phone")),
+    `else` = list(required = list("email")),
+    additionalProperties = FALSE
+  )
+  attr(tool, "mcp_input_schema") <- schema
+
+  res <- tool_as_json(tool)
+
+  expect_identical(res$inputSchema, schema)
+})
+
 test_that("tool_as_json gates top-level title on protocol version", {
   tool <- ellmer::tool(
     function() "ok",
@@ -241,6 +269,28 @@ test_that("handle_http_request_message marks tools/call as network-facing", {
   expect_match(
     res$error$message,
     "must not reference a private or loopback address"
+  )
+})
+
+test_that("execute_tool_call reports tool failures in the result", {
+  tool <- ellmer::tool(
+    function() stop("intentional tool failure", call. = FALSE),
+    "Always fails",
+    name = "failing_tool"
+  )
+
+  res <- execute_tool_call(list(
+    id = 1,
+    protocolVersion = "2025-11-25",
+    params = list(name = "failing_tool", arguments = list()),
+    tool = tool
+  ))
+
+  expect_null(res$error)
+  expect_true(res$result$isError)
+  expect_identical(
+    res$result$content,
+    list(list(type = "text", text = "intentional tool failure"))
   )
 })
 


### PR DESCRIPTION
Hi Posit / `mcptools` maintainers 👋

This is a bit of a crazy PR — but I'm an MCP maintainer (and I build GitHub's MCP server), and I was experimenting to see whether a top-end model plus the new official MCP **conformance test suite** could take `mcptools` all the way to a good result. I'll also be doing more manual testing, but a fully spec-conformant, fully-featured MCP SDK for R — including the new **2026-07-28** stateless spec — would be really cool, and I wanted to give it a try.

Opening as a **draft** for discussion, not for immediate merge.

## What this does
Elevates the `mcptools` server to pass the official MCP conformance suite (`@modelcontextprotocol/conformance`) across two spec versions:

- **2025-11-25 (current): 46 / 46** server scenarios green.
- **2026-07-28 (GA stateless lifecycle): 113 / 113** green across all 40 dated scenarios.

`make conformance` runs both as a ratcheted matrix and exits 0.

## How it's organized (6 reviewable commits)
1. **Conformance harness + method registry + core tool content types** — harness driver + CI, an additive self-registering method registry, and tool content handling (text / image / audio / embedded-resource / mixed, tool errors, JSON Schema 2020-12).
2. **Resources** — list, read (text/binary), templates, subscribe/unsubscribe.
3. **Prompts** — list, get (args, embedded resource, image).
4. **Completion & logging** — `completion/complete`, `logging/setLevel`.
5. **Streaming transport** — a raw-socket Streamable-HTTP / SSE transport (R's httpuv can't stream), with sampling + elicitation.
6. **2026-07-28 stateless** — per-request `_meta`, `server/discover`, caching hints, `subscriptions/listen` NDJSON, `tools/call` as SSE, the MRTR / input-required-result group, and cross-version routing.

## Notable design notes
- **Raw-socket transport:** httpuv/Rook can't do incremental writes, so long-lived SSE/NDJSON streams and bidirectional sampling/elicitation use a base-R `serverSocket`/`socketConnection` Streamable-HTTP transport, with an httpuv fallback.
- **Additive registry:** features self-register (`.register_mcp_*`), which is what let this be built as independent parallel workstreams and merged cleanly — and is why the commits are cleanly feature-scoped.
- **Cross-version:** the stateful 2025-06-18 / 2025-11-25 path is untouched; 2026-07-28 stateless is detected and routed separately.
- **HMAC-protected opaque request state** for the stateless MRTR flows.

## How to run
```sh
make conformance             # both spec legs
make conformance-2025-11-25
make conformance-2026-07-28
```
Needs R + Node; the harness is fetched via `npx`. The 2026-07-28 leg uses `@modelcontextprotocol/conformance@0.2.0-alpha.10` (the first release accepting the dated version), pinned per-leg and overridable via `CONFORMANCE_2025_VERSION` / `CONFORMANCE_2026_VERSION`.

## Caveats / honesty
- This was **largely AI-built** (hence the co-author trailers) as an experiment, then verified against the official suite — but it wants proper human review before anyone relies on it.
- Commits are grouped by feature for review; shared dispatch/transport plumbing lands in the foundation commit, so the package fully loads at the tip rather than being strictly bisectable per-commit.
- Full development history (parallel workspaces, per-feature branches) lives at https://github.com/SamMorrowDrums/r-mcp.

Happy to split this up, adapt naming/conventions to `mcptools`' style, or evolve it however is most useful. Thanks for `mcptools` — it was a great base to build on!
